### PR TITLE
fix: unblock Day 8a frontend build and update project status

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ That's it.
 
 ## Status
 
-🚧 **Early development** — backend complete through Day 6, frontend UI in progress.
+🚧 **Early development** — backend complete through Day 7, frontend score rendering (Day 8a) now working.
 
 | Component | Status |
 |-----------|--------|
@@ -53,8 +53,8 @@ That's it.
 | Audio capture (mic) | ✅ Done |
 | Pitch detection (torchcrepe/pYIN) | ✅ Done |
 | WebSocket pitch stream | ✅ Done |
-| Backend integration tests | 🔲 Day 7 |
-| Score renderer (OSMD) | 🔲 Day 8 |
+| Backend integration tests | ✅ Done |
+| Score renderer (OSMD) | ✅ Done (Day 8a) |
 | Score playback (Web Audio) | 🔲 Day 9 |
 | Real-time pitch overlay | 🔲 Day 10 |
 | Transport controls | 🔲 Day 11 |

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -9,7 +9,13 @@
     "noImplicitReturns": true,
     "outDir": "dist",
     "rootDir": "src",
-    "lib": ["ES2022", "DOM"]
+    "lib": [
+      "ESNext",
+      "DOM"
+    ],
+    "skipLibCheck": true
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }


### PR DESCRIPTION
### Motivation
- The TypeScript production build was failing in the current toolchain due to third-party declaration files referencing Node types and newer lib features, so the frontend needs a small tsconfig adjustment to compile reliably.
- The project status in `README.md` needed updating to reflect that backend integration tests and the Day 8a OSMD score renderer are now complete.

### Description
- Adjusted `frontend/tsconfig.json` to use `lib: ["ESNext","DOM"]` and enabled `skipLibCheck` to avoid external-declaration type errors during `tsc`.
- Updated `README.md` status text to mark backend integration tests as done and to mark the OSMD score renderer as complete (Day 8a).
- Changes are limited to `frontend/tsconfig.json` and `README.md` to unblock the frontend build and update project status.

### Testing
- Ran frontend unit tests with `cd frontend && npm test -- --run`, and the `vitest` suite passed (10 tests passed).
- Performed a frontend production build with `cd frontend && npm run build`, and the build completed successfully producing `dist/` artifacts.
- Executed `pytest -q` which failed to collect tests in this environment due to missing Python test dependencies (`httpx`, `torch`) unrelated to these frontend/docs changes.
- `npm install` attempted in this environment encountered a registry `403` (network/policy issue) but the existing `node_modules` allowed the build to succeed for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b1f80f5e98832796f183f1d546d1fe)