### PR TITLE
[Day 10] Note accuracy colouring — fix rest/pre-entry dot suppression

### DIFF
--- a/frontend/src/pitch/accuracy.test.ts
+++ b/frontend/src/pitch/accuracy.test.ts
@@ -25,14 +25,27 @@ describe('expectedNoteAtBeat', () => {
 });
 
 describe('classifyPitchColor', () => {
-  it('returns grey for low confidence or missing expected note', () => {
+  it('returns grey for low confidence (conf < 0.6)', () => {
     expect(classifyPitchColor(60, 60, 0.59)).toBe('grey');
-    expect(classifyPitchColor(60, null, 0.99)).toBe('grey');
   });
+
+  // Rest suppression is enforced by PitchOverlay.pushFrame() which checks
+  // expectedNoteAtBeat() and returns early when null — classifyPitchColor
+  // is never called during rests and no longer accepts null as expectedMidi.
 
   it('applies cents thresholds for green/amber/red', () => {
     expect(classifyPitchColor(60.49, 60, 0.8)).toBe('green');
     expect(classifyPitchColor(60.75, 60, 0.8)).toBe('amber');
     expect(classifyPitchColor(61.2, 60, 0.8)).toBe('red');
+  });
+
+  it('classifies a note exactly on the green boundary (50 cents inclusive)', () => {
+    // 0.50 semitones = exactly 50 cents — boundary is inclusive for green
+    expect(classifyPitchColor(60.50, 60, 0.8)).toBe('green');
+  });
+
+  it('classifies a note just inside amber (51 cents)', () => {
+    // 0.51 semitones = 51 cents — just above green threshold
+    expect(classifyPitchColor(60.51, 60, 0.8)).toBe('amber');
   });
 });

--- a/frontend/src/pitch/accuracy.ts
+++ b/frontend/src/pitch/accuracy.ts
@@ -27,8 +27,16 @@ export function expectedNoteAtBeat(beat: number, notes: NoteModel[]): NoteModel 
   return beat >= candidate.beat_start && beat < end ? candidate : null;
 }
 
-export function classifyPitchColor(sungMidi: number, expectedMidi: number | null, conf: number): DotColor {
-  if (conf < 0.6 || expectedMidi === null) return 'grey';
+/**
+ * Classify the dot colour for a voiced pitch frame.
+ *
+ * Precondition: expectedMidi is the MIDI value of the currently active note
+ * (i.e. expectedNoteAtBeat() returned non-null). Callers must not invoke this
+ * function during rests — use the null return from expectedNoteAtBeat() to
+ * suppress the dot entirely before reaching this function.
+ */
+export function classifyPitchColor(sungMidi: number, expectedMidi: number, conf: number): DotColor {
+  if (conf < 0.6) return 'grey';
 
   const cents = Math.abs((sungMidi - expectedMidi) * 100);
   if (cents <= 50) return 'green';

--- a/frontend/src/pitch/overlay.ts
+++ b/frontend/src/pitch/overlay.ts
@@ -71,7 +71,11 @@ export class PitchOverlay {
   pushFrame(frame: PitchFrame, cursorX: number): void {
     const beat = elapsedToBeat(frame.t, 0, this.model.tempo_marks);
     const expected = expectedNoteAtBeat(beat, this.notesForPart);
-    const color = classifyPitchColor(frame.midi, expected?.midi ?? null, frame.conf);
+
+    // No dot during rests or before the selected part's first note
+    if (expected === null) return;
+
+    const color = classifyPitchColor(frame.midi, expected.midi, frame.conf);
     const y = this.midiToY(frame.midi);
 
     this.dots.push({ x: cursorX, y, color, wallMs: performance.now() });


### PR DESCRIPTION
Closes #11

## What changed

The core accuracy-colouring logic (binary search, cent thresholds, green/amber/red/grey) was already scaffolded. The remaining gap: `pushFrame()` was rendering a grey dot during rests and before the selected part's first note, because `classifyPitchColor()` returned `'grey'` when `expectedMidi` was `null`.

### `overlay.ts` — early return on null expected note
Added a guard before `classifyPitchColor()` is called:
```ts
if (expected === null) return;
```
This suppresses dots during rests and pre-entry silence. No dot is pushed to `this.dots`, so nothing is drawn. The Part II beat 0–29 silence is handled automatically — `notesForPart` has no notes before beat 29, so `expectedNoteAtBeat` returns null throughout.

### `accuracy.ts` — tighten `classifyPitchColor` signature
`expectedMidi` parameter changed from `number | null` to `number`. The null branch is gone from the function body. TypeScript enforces the invariant: if a null ever leaks through, it's a compile error.

### `accuracy.test.ts` — updated tests
- Removed: `classifyPitchColor(60, null, 0.99)` assertion (null path no longer accepted)
- Added: boundary tests at exactly 50 cents (green, inclusive) and 51 cents (amber)
- Added: comment documenting where rest suppression is enforced

## Acceptance criteria

- [x] Rests show no dot
- [x] Part II silence (before beat 29) shows no dot  
- [x] Grey dot only for low-confidence frames where a note IS active
- [x] Colour assignment is instant (no gradual transition on the current dot)
- [x] `vitest run` passes — one test case removed, two added