### PR TITLE
[Day 10] Note accuracy colouring — fix rest/pre-entry dot suppression

### DIFF
--- a/frontend/src/pitch/accuracy.test.ts
+++ b/frontend/src/pitch/accuracy.test.ts
@@ -25,9 +25,19 @@ describe('expectedNoteAtBeat', () => {
 });
 
 describe('classifyPitchColor', () => {
-  it('returns grey for low confidence or missing expected note', () => {
+  it('returns grey for low confidence (conf < 0.6)', () => {
+    // Low confidence maps to grey when a note is expected; rest suppression is handled in PitchOverlay.pushFrame().
     expect(classifyPitchColor(60, 60, 0.59)).toBe('grey');
-    expect(classifyPitchColor(60, null, 0.99)).toBe('grey');
+  });
+
+  it('classifies a note exactly on the green boundary', () => {
+    // 0.50 semitones = exactly 50 cents — boundary is inclusive for green
+    expect(classifyPitchColor(60.50, 60, 0.8)).toBe('green');
+  });
+
+  it('classifies a note just inside amber', () => {
+    // 0.51 semitones = 51 cents — just above green threshold
+    expect(classifyPitchColor(60.51, 60, 0.8)).toBe('amber');
   });
 
   it('applies cents thresholds for green/amber/red', () => {

--- a/frontend/src/pitch/accuracy.ts
+++ b/frontend/src/pitch/accuracy.ts
@@ -27,8 +27,8 @@ export function expectedNoteAtBeat(beat: number, notes: NoteModel[]): NoteModel 
   return beat >= candidate.beat_start && beat < end ? candidate : null;
 }
 
-export function classifyPitchColor(sungMidi: number, expectedMidi: number | null, conf: number): DotColor {
-  if (conf < 0.6 || expectedMidi === null) return 'grey';
+export function classifyPitchColor(sungMidi: number, expectedMidi: number, conf: number): DotColor {
+  if (conf < 0.6) return 'grey';
 
   const cents = Math.abs((sungMidi - expectedMidi) * 100);
   if (cents <= 50) return 'green';

--- a/frontend/src/pitch/overlay.ts
+++ b/frontend/src/pitch/overlay.ts
@@ -71,7 +71,11 @@ export class PitchOverlay {
   pushFrame(frame: PitchFrame, cursorX: number): void {
     const beat = elapsedToBeat(frame.t, 0, this.model.tempo_marks);
     const expected = expectedNoteAtBeat(beat, this.notesForPart);
-    const color = classifyPitchColor(frame.midi, expected?.midi ?? null, frame.conf);
+
+    // No dot during rests or before the selected part's first note.
+    if (expected === null) return;
+
+    const color = classifyPitchColor(frame.midi, expected.midi, frame.conf);
     const y = this.midiToY(frame.midi);
 
     this.dots.push({ x: cursorX, y, color, wallMs: performance.now() });


### PR DESCRIPTION
### Motivation

- Fix a bug where pitch dots were rendered during score rests and before the selected part's first note because `expectedNoteAtBeat()` returning `null` was implicitly producing a grey dot.

### Description

- Suppress dot creation in `PitchOverlay.pushFrame()` by returning early when `expectedNoteAtBeat(...)` is `null`, so no dot is appended during rests or pre-entry silence (`frontend/src/pitch/overlay.ts`).
- Tighten `classifyPitchColor` to require a non-null `expectedMidi: number` and remove the obsolete `expectedMidi === null` branch while keeping low-confidence grey behaviour (`frontend/src/pitch/accuracy.ts`).
- Update unit tests to reflect the new contract by removing the null-expected assertion, clarifying the low-confidence test, and adding boundary tests for 50-cent (green) and 51-cent (amber) cases (`frontend/src/pitch/accuracy.test.ts`).

### Testing

- Ran `cd frontend && npx vitest run --reporter=verbose` and all tests passed successfully.
- Test summary: `Test Files 5 passed (5)` and `Tests 39 passed (39)`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b40c083b348327b420d922002eb645)