### PR TITLE
fix: transport control gaps from PR #39 (issue #44)

### DIFF
--- a/backend/audio/pipeline.py
+++ b/backend/audio/pipeline.py
@@ -80,6 +80,11 @@ class PlaybackPipeline:
         self._elapsed_ms: float = 0.0       # accumulated ms before last pause
         self._tempo_multiplier: float = 1.0
 
+        # Transposition — semitones offset kept in sync with the frontend Web Audio
+        # detune value; used by the pitch interpretation layer (Day 9) to shift
+        # expected MIDI targets when comparing detected f0 against score notes.
+        self._transpose_semitones: int = 0
+
         # Hardware objects — created on start, destroyed on stop
         self._capture: MicCapture | None = None
         self._pitch: PitchPipeline | None = None
@@ -163,6 +168,17 @@ class PlaybackPipeline:
                 self._play_monotonic = time.monotonic()
             log.info("PlaybackPipeline seeked to t=%.1f ms (state=%s)", self._elapsed_ms, self._state.name)
 
+
+    def set_transpose_semitones(self, semitones: int) -> None:
+        """Set the active transposition offset in semitones (clamped to ±12)."""
+        with self._lock:
+            self._transpose_semitones = max(-12, min(12, int(semitones)))
+            log.info("PlaybackPipeline transpose set to %d semitones", self._transpose_semitones)
+
+    @property
+    def transpose_semitones(self) -> int:
+        with self._lock:
+            return self._transpose_semitones
 
     def set_tempo_multiplier(self, multiplier: float) -> None:
         with self._lock:

--- a/backend/main.py
+++ b/backend/main.py
@@ -139,6 +139,28 @@ async def playback_tempo(multiplier: float) -> JSONResponse:
     )
 
 
+@app.post("/playback/transpose")
+async def playback_transpose(semitones: int) -> JSONResponse:
+    """
+    Set the active transposition offset in semitones.
+
+    The frontend applies the same offset to Web Audio detune so the audio
+    played back is shifted. This endpoint stores the offset so the pitch
+    interpretation layer (Day 9) can shift expected MIDI targets when
+    comparing detected f0 against score notes.
+
+    Range clamped to [-12, +12] on the pipeline side.
+    """
+    _pipeline.set_transpose_semitones(semitones)
+    return JSONResponse(
+        {
+            "state": _pipeline.state.name,
+            "t_ms": _pipeline.elapsed_ms,
+            "transpose_semitones": _pipeline.transpose_semitones,
+        }
+    )
+
+
 # ── WebSocket pitch stream ─────────────────────────────────────────────────────
 
 

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -157,6 +157,53 @@ class TestPlaybackStateMachine:
 
         assert p.elapsed_ms >= 40.0
 
+    def test_set_tempo_multiplier_while_stopped_only_stores_value(self):
+        """set_tempo_multiplier on a STOPPED pipeline must not accumulate elapsed."""
+        p = self._pipeline()
+        p.set_tempo_multiplier(2.0)
+        assert p.tempo_multiplier == pytest.approx(2.0)
+        assert p.elapsed_ms == 0.0
+
+    def test_set_tempo_multiplier_while_paused_only_stores_value(self):
+        """set_tempo_multiplier on a PAUSED pipeline must not accumulate elapsed."""
+        p = self._pipeline()
+        p._state = PlaybackState.PAUSED
+        p._elapsed_ms = 300.0
+        p.set_tempo_multiplier(0.75)
+        assert p.tempo_multiplier == pytest.approx(0.75)
+        assert p.elapsed_ms == pytest.approx(300.0)
+
+    def test_set_tempo_multiplier_rejects_zero_directly(self):
+        """set_tempo_multiplier(0) must raise ValueError on the pipeline itself.
+
+        The HTTP endpoint validates first (HTTPException), but direct callers
+        must also be protected. This covers the raise-ValueError line.
+        """
+        p = self._pipeline()
+        with pytest.raises(ValueError, match="multiplier must be > 0"):
+            p.set_tempo_multiplier(0)
+
+    def test_set_transpose_semitones_stores_value(self):
+        p = self._pipeline()
+        p.set_transpose_semitones(3)
+        assert p.transpose_semitones == 3
+
+    def test_set_transpose_semitones_clamps_to_plus_12(self):
+        p = self._pipeline()
+        p.set_transpose_semitones(99)
+        assert p.transpose_semitones == 12
+
+    def test_set_transpose_semitones_clamps_to_minus_12(self):
+        p = self._pipeline()
+        p.set_transpose_semitones(-99)
+        assert p.transpose_semitones == -12
+
+    def test_set_transpose_semitones_allows_zero(self):
+        p = self._pipeline()
+        p.set_transpose_semitones(7)
+        p.set_transpose_semitones(0)
+        assert p.transpose_semitones == 0
+
     def test_double_start_is_safe(self):
         p = self._pipeline()
         p._capture = _MockCapture()
@@ -353,6 +400,35 @@ class TestPlaybackEndpoints:
     def test_playback_tempo_rejects_invalid_multiplier(self, client):
         resp = client.post('/playback/tempo?multiplier=0')
         assert resp.status_code == 400
+
+    def test_playback_transpose_returns_200(self, client):
+        resp = client.post('/playback/transpose?semitones=3')
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data['transpose_semitones'] == 3
+
+    def test_playback_transpose_negative_semitones(self, client):
+        resp = client.post('/playback/transpose?semitones=-5')
+        assert resp.status_code == 200
+        assert resp.json()['transpose_semitones'] == -5
+
+    def test_playback_transpose_clamps_out_of_range(self, client):
+        resp = client.post('/playback/transpose?semitones=99')
+        assert resp.status_code == 200
+        assert resp.json()['transpose_semitones'] == 12
+
+    def test_playback_transpose_zero_resets(self, client):
+        client.post('/playback/transpose?semitones=6')
+        resp = client.post('/playback/transpose?semitones=0')
+        assert resp.status_code == 200
+        assert resp.json()['transpose_semitones'] == 0
+
+    def test_playback_transpose_returns_state_and_t_ms(self, client):
+        resp = client.post('/playback/transpose?semitones=2')
+        data = resp.json()
+        assert 'state' in data
+        assert 't_ms' in data
+        assert 'transpose_semitones' in data
 
     def test_state_schema(self, client):
         resp = client.get("/playback/state")

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -19,7 +19,7 @@ import { PlaybackEngine } from './playback/engine';
 import { PitchOverlay } from './pitch/overlay';
 import { parsePitchFrame, reconnectDelayMs } from './pitch/socket';
 import { getVisiblePartOptions } from './part-options';
-import { beatToMs, postPlayback, seekPlayback, setPlaybackTempo } from './transport/controls';
+import { beatToMs, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose } from './transport/controls';
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
@@ -56,7 +56,6 @@ let soundfontLoadPromise: Promise<void> | null = null;
 
 // External cursor RAF (replaces ScoreCursor's internal wall-clock loop)
 let cursorRafId: number | null = null;
-const SEEK_STEP_BEATS = 4;
 let pitchOverlay: PitchOverlay | null = null;
 let pitchWs: WebSocket | null = null;
 let pitchReconnectTimer: number | null = null;
@@ -170,7 +169,7 @@ async function loadScore(file: File): Promise<void> {
     if (!audioCtx || !soundfont) throw new Error('AudioContext not available');
 
     engine = new PlaybackEngine(audioCtx, soundfont);
-    engine.setTransposeSemitones(parseInt(transposeSelectEl.value, 10) || 0);
+    engine.setTransposeSemitones(getTransposeSemitones());
     engine.schedule(
       model.notes,
       model.tempo_marks,
@@ -219,14 +218,25 @@ function stopCursorRaf(): void {
   }
 }
 
+/**
+ * Seek forward or backward by one bar.
+ *
+ * Step size is derived from the score's first time signature numerator so the
+ * jump is always a whole bar (e.g. 3 beats in 3/4, 4 in 4/4). Falls back to
+ * 4 if the score has no time signature data.
+ *
+ * Backend seek is awaited before moving the frontend to avoid a race where
+ * the frontend has moved but the backend still emits frames from the old position.
+ */
 async function seekByBeats(delta: number): Promise<void> {
   if (!engine || !cursor || !renderer?.scoreModel) return;
   const totalBeats = renderer.scoreModel.total_beats;
-  const targetBeat = Math.max(0, Math.min(totalBeats, engine.currentBeat + delta));
+  const stepBeats = renderer.scoreModel.time_signatures[0]?.numerator ?? 4;
+  const targetBeat = Math.max(0, Math.min(totalBeats, engine.currentBeat + delta * stepBeats));
   try {
     await seekPlayback(beatToMs(targetBeat, renderer.scoreModel, engine.tempoMultiplier));
   } catch (err) {
-    setStatus('seek failed', 'error');
+    setStatus(`seek failed: ${String(err)}`, 'error');
     console.error('Seek failed:', err);
     return;
   }
@@ -234,6 +244,12 @@ async function seekByBeats(delta: number): Promise<void> {
   engine.seekToBeat(targetBeat);
   cursor.seekToBeat(targetBeat);
   if (engine.state !== 'playing') stopCursorRaf();
+}
+
+/** Read the current transpose selector value as an integer, defaulting to 0. */
+function getTransposeSemitones(): number {
+  const parsed = parseInt(transposeSelectEl.value, 10);
+  return Number.isNaN(parsed) ? 0 : parsed;
 }
 
 function cursorXPosition(): number {
@@ -324,7 +340,7 @@ function scheduleSelectedPart(selectedPart: string): void {
     selectedPart,
     parseFloat(tempoSliderEl.value) / 100,
   );
-  engine.setTransposeSemitones(parseInt(transposeSelectEl.value, 10) || 0);
+  engine.setTransposeSemitones(getTransposeSemitones());
 
   if (engine.state === 'playing') {
     engine.stop();
@@ -376,7 +392,7 @@ btnPlay.addEventListener('click', async () => {
     engine.play(fromBeat);
     startCursorRaf();
   } catch (err) {
-    setStatus('playback start failed', 'error');
+    setStatus(`playback start failed: ${String(err)}`, 'error');
     console.error('Play failed:', err);
   }
 });
@@ -388,7 +404,7 @@ btnPause.addEventListener('click', async () => {
     engine.pause();
     stopCursorRaf();
   } catch (err) {
-    setStatus('pause failed', 'error');
+    setStatus(`pause failed: ${String(err)}`, 'error');
     console.error('Pause failed:', err);
   }
 });
@@ -403,7 +419,7 @@ btnStop.addEventListener('click', async () => {
     pitchOverlay?.clear();
     headphoneWarning.classList.add('hidden');
   } catch (err) {
-    setStatus('stop failed', 'error');
+    setStatus(`stop failed: ${String(err)}`, 'error');
     console.error('Stop failed:', err);
   }
 });
@@ -413,7 +429,7 @@ btnRewind.addEventListener('click', async () => {
   try {
     await postPlayback('/playback/stop');
   } catch (err) {
-    setStatus('rewind failed', 'error');
+    setStatus(`rewind failed: ${String(err)}`, 'error');
     console.error('Rewind failed:', err);
   }
   engine.stop();
@@ -455,16 +471,22 @@ tempoSliderEl.addEventListener('change', async () => {
     engine.setTempoMultiplier(previousMultiplier);
     tempoSliderEl.value = String(Math.round(previousMultiplier * 100));
     tempoLabelEl.textContent = `${tempoSliderEl.value}%`;
-    setStatus('tempo update failed', 'error');
+    setStatus(`tempo update failed: ${String(err)}`, 'error');
     console.error('Tempo update failed:', err);
   }
 });
 
 // ── Transpose selector ───────────────────────────────────────────────────────
 
-transposeSelectEl.addEventListener('change', () => {
-  const semitones = parseInt(transposeSelectEl.value, 10);
-  engine?.setTransposeSemitones(Number.isNaN(semitones) ? 0 : semitones);
+transposeSelectEl.addEventListener('change', async () => {
+  const semitones = getTransposeSemitones();
+  engine?.setTransposeSemitones(semitones);
+  try {
+    await setPlaybackTranspose(semitones);
+  } catch (err) {
+    setStatus(`transpose sync failed: ${String(err)}`, 'error');
+    console.error('Transpose sync failed:', err);
+  }
 });
 
 // ── Headphone warning dismiss ─────────────────────────────────────────────────
@@ -499,13 +521,13 @@ window.addEventListener('keydown', (e) => {
 
   if (e.key === 'ArrowLeft') {
     e.preventDefault();
-    void seekByBeats(-SEEK_STEP_BEATS);
+    void seekByBeats(-1);
     return;
   }
 
   if (e.key === 'ArrowRight') {
     e.preventDefault();
-    void seekByBeats(SEEK_STEP_BEATS);
+    void seekByBeats(1);
   }
 });
 

--- a/frontend/src/playback/engine.ts
+++ b/frontend/src/playback/engine.ts
@@ -189,7 +189,15 @@ export class PlaybackEngine {
    * If not playing: stores the multiplier for the next play() call.
    */
 
-  /** Seek to a beat position; if playing, reschedule immediately from that beat. */
+  /**
+   * Seek to a beat position.
+   *
+   * If playing, cancels all future scheduled sources and immediately reschedules
+   * from `beat` with a short `RESCHEDULE_OFFSET_S` gap to avoid audible overlap.
+   * If paused or idle, stores the beat for the next `play()` call.
+   *
+   * @param beat - Target beat number. Values below 0 are clamped to 0.
+   */
   seekToBeat(beat: number): void {
     const targetBeat = Math.max(0, beat);
     if (this._state === 'playing') {

--- a/frontend/src/transport/controls.ts
+++ b/frontend/src/transport/controls.ts
@@ -16,6 +16,32 @@ export async function setPlaybackTempo(multiplier: number): Promise<void> {
   if (!res.ok) throw new Error(`Playback command failed: /playback/tempo (HTTP ${res.status})`);
 }
 
+/**
+ * Notify the backend of the active transposition offset.
+ *
+ * The frontend applies the same offset via PlaybackEngine.setTransposeSemitones()
+ * which adjusts Web Audio detune. Calling this endpoint keeps the backend
+ * pipeline in sync so the pitch interpretation layer (Day 9) can shift
+ * expected MIDI targets when comparing detected f0 against score notes.
+ *
+ * @param semitones - Integer semitone offset, clamped to [-12, +12] server-side.
+ */
+export async function setPlaybackTranspose(semitones: number): Promise<void> {
+  const res = await fetch(
+    `/playback/transpose?semitones=${encodeURIComponent(Math.round(semitones))}`,
+    { method: 'POST' },
+  );
+  if (!res.ok) throw new Error(`Playback command failed: /playback/transpose (HTTP ${res.status})`);
+}
+
+/**
+ * Convert a beat position to milliseconds using the score's tempo map.
+ *
+ * @param beat - Beat number relative to score start.
+ * @param scoreModel - Score model containing the tempo mark array.
+ * @param tempoMultiplier - Current playback speed multiplier (1.0 = normal).
+ * @returns Elapsed milliseconds from beat 0 to the given beat.
+ */
 export function beatToMs(beat: number, scoreModel: ScoreModel, tempoMultiplier: number): number {
   return beatToSeconds(beat, scoreModel.tempo_marks, tempoMultiplier) * 1000;
 }


### PR DESCRIPTION
- Add POST /playback/transpose + PlaybackPipeline.set_transpose_semitones() so backend tracks active transposition for Day 9 pitch comparison
- Wire transposeSelectEl handler to call both engine and backend in sync
- Cover 2 missing pipeline.py lines: ValueError raise + non-PLAYING tempo paths
- Extract getTransposeSemitones() helper; remove parseInt duplication
- seekByBeats step derived from time_signatures[0].numerator, not hardcoded 4
- Add JSDoc on seekToBeat() and beatToMs()
- Standardise all transport error messages to include String(err)

Closes #44