### PR TITLE
docs: add cross-platform just installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,9 +68,26 @@ That's it.
 - Python 3.12+
 - Node 18+
 - [uv](https://github.com/astral-sh/uv) — `winget install astral-sh.uv`
-- [just](https://github.com/casey/just) — `winget install Casey.Just`
+- [just](https://github.com/casey/just)
 - NVIDIA GPU with CUDA 12.x recommended (for torchcrepe pitch detection; librosa pYIN works on CPU)
 - **Headphones** — essential during practice to prevent mic picking up the playback
+
+### Install `just`
+
+Use the package manager that matches your system:
+
+- **Windows (winget)**: `winget install Casey.Just`
+- **Windows (Scoop)**: `scoop install just`
+- **Windows (Chocolatey)**: `choco install just`
+- **macOS (Homebrew)**: `brew install just`
+- **Ubuntu/Debian**: `sudo apt install just`
+- **Cross-platform via Cargo**: `cargo install just`
+
+Verify install:
+
+```powershell
+just --version
+```
 
 ---
 


### PR DESCRIPTION
### Motivation
- Clarify installation of `just` by providing platform- and package-manager-specific instructions instead of a single Windows-only install line.

### Description
- Update `README.md` to remove the Windows-only inline install and add an "Install `just`" section listing install commands for `winget`, `scoop`, `choco`, `brew`, `apt`, and `cargo`, plus a verification command `just --version`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4369e00648327bd5e6a6f271586e3)