### PR TITLE
Set PowerShell as Windows shell for just recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -10,6 +10,9 @@
 backend-dir := "backend"
 frontend-dir := "frontend"
 
+# Use PowerShell when running recipes on Windows so `just` doesn't depend on `sh`.
+set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
+
 # Install all dependencies
 install:
     uv sync


### PR DESCRIPTION
### Motivation
- Fix `just` failing on Windows systems that lack a POSIX `sh` by forcing recipes to run via PowerShell.

### Description
- Add `set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]` to the `justfile` so `just` will invoke PowerShell on Windows.

### Testing
- Ran `just --dry-run dev-backend` as an automated dry-run but it could not be executed because `just` is not installed in this environment, so the dry-run failed to run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b438d822108327ab9cdc1376069384)