### PR TITLE
Use PowerShell-compatible separators in justfile frontend recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]
 # Install all dependencies
 install:
     uv sync
-    cd {{frontend-dir}} && npm install
+    cd {{frontend-dir}}; npm install
 
 # Start FastAPI backend (reload on change)
 dev-backend:
@@ -24,7 +24,7 @@ dev-backend:
 
 # Start Vite frontend dev server
 dev-frontend:
-    cd {{frontend-dir}} && npm run dev
+    cd {{frontend-dir}}; npm run dev
 
 # Run backend tests
 test:
@@ -32,4 +32,4 @@ test:
 
 # Build frontend for production
 build-frontend:
-    cd {{frontend-dir}} && npm run build
+    cd {{frontend-dir}}; npm run build


### PR DESCRIPTION
### Motivation
- Fix a Windows PowerShell parse error by making frontend `npm` invocations in `justfile` use a PowerShell-compatible statement separator instead of `&&` so recipes run under the configured `powershell.exe` shell.

### Description
- Replaced `&&` with `;` in the `install`, `dev-frontend`, and `build-frontend` recipes in `justfile`, and left `set windows-shell := ["powershell.exe", "-NoLogo", "-Command"]` unchanged.

### Testing
- Attempted `just --list`, which failed because `just` is not installed in this environment (`command not found`).
- Ran `git status --short` and created the commit via `git commit -m "Fix just recipes for PowerShell command chaining"`, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b439ac388083279b7036865252daa2)