### PR TITLE
Fix initial score loading UX deadlock in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -152,6 +152,7 @@
     #drop-zone {
       position: absolute;
       inset: 0;
+      z-index: 5;
       display: flex;
       flex-direction: column;
       align-items: center;
@@ -177,6 +178,7 @@
     #score-container {
       position: absolute;
       inset: 0;
+      z-index: 1;
       overflow-x: auto;
       overflow-y: auto;
       padding: 16px;

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -571,7 +571,6 @@ function setTransportEnabled(enabled: boolean): void {
   partSelectEl.disabled = !enabled;
   tempoSliderEl.disabled = !enabled;
   transposeSelectEl.disabled = !enabled;
-  btnBrowse.disabled = !enabled;
 }
 
 window.addEventListener('beforeunload', () => {


### PR DESCRIPTION
### Motivation
- The app appeared inert on first load because the drop zone was rendered beneath the white score canvas and the `Browse…` button was disabled until transport was enabled, creating a deadlock that prevented users from loading a MusicXML file.

### Description
- Make the drop zone visible above the score by adding `z-index` values to `#drop-zone` and `#score-container`, and keep the `Browse…` control enabled by removing it from `setTransportEnabled` in `frontend/src/main.ts`.

### Testing
- Ran frontend unit tests and build: `npm test` (frontend) passed and `npm run build` (frontend) passed, and an automated attempt to start the backend via `uvicorn` failed in the container due to a missing PortAudio system library (`OSError: PortAudio library not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43ada85108327ba72535436a21e96)