### PR TITLE
Fix missing Vite proxy route for playback endpoints

### DIFF
--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
       '/health': 'http://127.0.0.1:8000',
       '/score': 'http://127.0.0.1:8000',
       '/audio': 'http://127.0.0.1:8000',
+      '/playback': 'http://127.0.0.1:8000',
       '/ws': {
         target: 'ws://127.0.0.1:8000',
         ws: true,


### PR DESCRIPTION
### Motivation
- The frontend dev server returned `HTTP 404` for playback control routes (e.g. `/playback/start`) because the Vite proxy was not forwarding `/playback` requests to the FastAPI backend.

### Description
- Add the `/playback` proxy mapping in `frontend/vite.config.ts` so dev requests to `/playback` are forwarded to `http://127.0.0.1:8000`.

### Testing
- Ran `npm test` in `frontend` which passed all tests, and ran `npm run build` in `frontend` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b43cd7539883278d8b9f2608a93896)