### PR TITLE
Make settings panel dismissible (outside click & Escape)

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -564,10 +564,32 @@ warningDismiss.addEventListener('click', () => {
 
 
 
-btnSettings.addEventListener('click', async () => {
+btnSettings.addEventListener('click', async (event) => {
+  // Keep this click from immediately triggering the outside-click handler.
+  event.stopPropagation();
   const visible = settingsPanelEl.classList.toggle('visible');
   if (!visible) return;
   await refreshAudioSettings();
+});
+
+settingsPanelEl.addEventListener('click', (event) => {
+  // Interacting with controls inside the panel should not close it.
+  event.stopPropagation();
+});
+
+window.addEventListener('click', (event) => {
+  if (!settingsPanelEl.classList.contains('visible')) return;
+
+  const target = event.target;
+  if (!(target instanceof Node)) return;
+
+  if (settingsPanelEl.contains(target) || btnSettings.contains(target)) return;
+  settingsPanelEl.classList.remove('visible');
+});
+
+window.addEventListener('keydown', (event) => {
+  if (event.key !== 'Escape') return;
+  settingsPanelEl.classList.remove('visible');
 });
 
 settingsDeviceEl.addEventListener('change', () => {


### PR DESCRIPTION
### Motivation
- The settings panel could not be reliably closed after opening because clicks bubbled to a global handler and there was no keyboard shortcut to dismiss it.
- Users need the panel to remain interactive without accidental outside-clicks closing it.

### Description
- Stop propagation on the settings button click and on clicks inside the settings panel to prevent immediate outside-click dismissal by adding `event.stopPropagation()` in the button handler and a click handler on the panel.
- Add a global `window` click listener that closes the panel when the user clicks outside the panel or the settings button.
- Add a `keydown` handler to close the panel when the `Escape` key is pressed.
- Changes are implemented in `frontend/src/main.ts`.

### Testing
- Ran the frontend test suite with `npm test` (Vitest), and all tests passed (`7 files, 51 tests` succeeded).
- Executed an automated Playwright script that opened the dev server, clicked the settings button, then clicked outside and captured screenshots showing the panel opened and then closed, and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4433384e08327aa9abcbdc5f93bca)