### PR TITLE
Fix pitch overlay note trail alignment during horizontal scroll

### DIFF
--- a/frontend/src/pitch/overlay.ts
+++ b/frontend/src/pitch/overlay.ts
@@ -139,6 +139,7 @@ export class PitchOverlay {
   private redraw = (): void => {
     this.resize();
     const now = performance.now();
+    const scrollLeft = this.container.scrollLeft;
     this.ctx.clearRect(0, 0, this.canvas.width, this.canvas.height);
 
     for (const dot of this.dots) {
@@ -149,7 +150,10 @@ export class PitchOverlay {
       this.ctx.globalAlpha = alpha;
       this.ctx.fillStyle = this.colorToCss(dot.color);
       this.ctx.beginPath();
-      this.ctx.arc(dot.x, dot.y, 4, 0, Math.PI * 2);
+      // Dot x is recorded in score-content coordinates. Convert back to
+      // viewport coordinates each redraw so dots stay attached to notes while
+      // the score container auto-scrolls.
+      this.ctx.arc(dot.x - scrollLeft, dot.y, 4, 0, Math.PI * 2);
       this.ctx.fill();
     }
     this.ctx.globalAlpha = 1;


### PR DESCRIPTION
### Motivation
- Ensure sung-note dots recorded in score-content coordinates remain visually anchored to their notes when the score container scrolls horizontally, preventing dots from appearing shifted or only near the latest cursor area.

### Description
- During redraw, subtract `this.container.scrollLeft` from stored dot `x` positions so dots (recorded in content-space) are converted to viewport coordinates before drawing, with a clarifying inline comment.

### Testing
- Ran frontend unit tests with `npm test` in `frontend/` and all tests passed (7 files, 53 tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b445652cb88327a7a5a144f695af55)