### PR TITLE
Anchor pitch-frame timestamps to capture time to fix one-note lag

### DIFF
--- a/backend/audio/pipeline.py
+++ b/backend/audio/pipeline.py
@@ -252,7 +252,13 @@ class PlaybackPipeline:
         with self._lock:
             if self._state != PlaybackState.PLAYING:
                 return
-            t_ms = self._elapsed_ms + (time.monotonic() - self._play_monotonic) * 1000.0 * self._tempo_multiplier
+
+            # Use the frame's capture timestamp to avoid adding inference/
+            # queue latency to `t`. This keeps note matching aligned with
+            # the audio that actually produced the detected pitch.
+            play_anchor_ms = self._play_monotonic * 1000.0
+            frame_elapsed_ms = max(0.0, frame.time_ms - play_anchor_ms)
+            t_ms = self._elapsed_ms + (frame_elapsed_ms * self._tempo_multiplier)
 
         payload = {
             "t": round(t_ms, 1),

--- a/backend/tests/test_pipeline.py
+++ b/backend/tests/test_pipeline.py
@@ -346,6 +346,29 @@ class TestFrameFanout:
 
         asyncio.run(_run())
 
+    def test_frame_timestamp_uses_capture_time_not_emit_time(self):
+        """Frame `t` should be anchored to PitchFrame.time_ms to avoid lag."""
+        async def _run():
+            loop = asyncio.get_event_loop()
+            p = PlaybackPipeline()
+            p._loop = loop
+            p._state = PlaybackState.PLAYING
+            p._play_monotonic = 10.0
+            p._elapsed_ms = 250.0
+            p._tempo_multiplier = 1.0
+
+            q: asyncio.Queue = asyncio.Queue()
+            p.add_client(q)
+
+            frame = PitchFrame(time_ms=10250.0, midi=60.0, confidence=0.8)
+            await loop.run_in_executor(None, p._on_pitch_frame, frame)
+            await asyncio.sleep(0)
+
+            payload = q.get_nowait()
+            assert payload["t"] == pytest.approx(500.0)
+
+        asyncio.run(_run())
+
 
 # ── HTTP endpoints ─────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
### Motivation
- Observed “one note behind” behavior was caused by backend pitch frames being timestamped at emit time, which added inference/queue latency and misaligned detected pitch with the originating audio frame.
- The change aims to ensure pitch-to-score matching uses the original capture timestamp so the frontend compares detected pitch to the correct note.

### Description
- In `backend/audio/pipeline.py` updated `PlaybackPipeline._on_pitch_frame` to compute `t` using the incoming `PitchFrame.time_ms` anchored to the pipeline play anchor (`_play_monotonic`) and adjusted by `_elapsed_ms` and `_tempo_multiplier` instead of using the current wall clock at emit time.
- Added a regression test `test_frame_timestamp_uses_capture_time_not_emit_time` to `backend/tests/test_pipeline.py` which verifies the emitted payload's `t` is derived from the frame capture time and play anchor.
- Kept existing payload rounding for `t`, `midi`, and `conf` unchanged (still rounded to 0.1 ms and 3 decimal places respectively).

### Testing
- Attempted to run `pytest backend/tests/test_pipeline.py -q`, which initially failed due to a missing `httpx` dependency and was installed with `python -m pip install httpx`.
- Subsequent test runs were blocked by the environment lacking the PortAudio runtime required by `sounddevice` (error: "PortAudio library not found"), preventing full test collection in this environment.
- Performed `python -m compileall` on the modified modules to validate syntax, and the new test was added to the suite for CI where full pytest will exercise the change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b444f0585883279f077746ac70d772)