### PR TITLE
Add optional note-name display for detected pitch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,6 +141,13 @@
       margin-left: 4px;
     }
 
+    #pitch-readout {
+      font-size: 0.8rem;
+      color: #bfc6d8;
+      margin-left: 8px;
+      min-width: 120px;
+    }
+
     /* ── Main content area ── */
     main {
       flex: 1;
@@ -354,6 +361,7 @@
     <button id="btn-browse" class="transport-btn">Browse…</button>
     <button id="btn-settings" class="transport-btn">⚙ Settings</button>
 
+    <span id="pitch-readout" aria-live="polite">Pitch: --</span>
     <span id="score-info"></span>
   </div>
 
@@ -371,6 +379,13 @@
     <div class="settings-row">
       <label for="settings-trail">Pitch trail length: <span id="settings-trail-label">2.0s</span></label>
       <input id="settings-trail" type="range" min="0.5" max="5" step="0.5" value="2" />
+    </div>
+
+    <div class="settings-row">
+      <label for="settings-show-note-names">
+        <input id="settings-show-note-names" type="checkbox" />
+        Show note names
+      </label>
     </div>
 
     <div id="settings-engine">Pitch engine: loading…</div>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,10 +18,10 @@ import { SoundfontLoader } from './playback/soundfont';
 import { PlaybackEngine } from './playback/engine';
 import { MIN_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from './pitch/overlay';
 import { parsePitchFrame, reconnectDelayMs } from './pitch/socket';
+import { midiToFrequencyHz, midiToNoteName } from './pitch/note';
 import { getVisiblePartOptions } from './part-options';
-import { beatToMs, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose } from './transport/controls';
+import { beatToMs, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose, startPlayback } from './transport/controls';
 import { elapsedToBeat } from './score/timing';
-import { beatToMs, startPlayback, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose } from './transport/controls';
 import { resolveSelectedDeviceId, type AudioInputDevice } from './audio/devices';
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
@@ -52,7 +52,9 @@ const settingsConfidenceEl = document.getElementById('settings-confidence') as H
 const settingsConfidenceLabelEl = document.getElementById('settings-confidence-label') as HTMLSpanElement;
 const settingsTrailEl = document.getElementById('settings-trail') as HTMLInputElement;
 const settingsTrailLabelEl = document.getElementById('settings-trail-label') as HTMLSpanElement;
+const settingsShowNoteNamesEl = document.getElementById('settings-show-note-names') as HTMLInputElement;
 const settingsEngineEl = document.getElementById('settings-engine') as HTMLDivElement;
+const pitchReadoutEl = document.getElementById('pitch-readout') as HTMLSpanElement;
 
 // ── Module state ──────────────────────────────────────────────────────────────
 
@@ -79,6 +81,8 @@ const overlaySettings: OverlaySettings = {
   confidenceThreshold: MIN_CONFIDENCE_THRESHOLD,
   trailMs: 2000,
 };
+let showNoteNames = false;
+let lastDetectedMidi: number | null = null;
 let selectedDeviceId: number | null = null;
 
 // ── Backend health ────────────────────────────────────────────────────────────
@@ -374,11 +378,23 @@ function connectPitchSocket(): void {
     const frame = parsePitchFrame(payload);
     if (!frame) return;
 
+    lastDetectedMidi = frame.midi;
+    updatePitchReadout(frame.midi);
+
     pitchOverlay.pushFrame(
       frame,
       frameXPosition(frame.t),
     );
   };
+}
+
+function updatePitchReadout(midi: number): void {
+  const frequency = midiToFrequencyHz(midi);
+  if (!Number.isFinite(frequency)) return;
+  const frequencyLabel = `${Math.round(frequency)} Hz`;
+  pitchReadoutEl.textContent = showNoteNames
+    ? `Pitch: ${frequencyLabel} → ${midiToNoteName(midi)}`
+    : `Pitch: ${frequencyLabel}`;
 }
 
 function scheduleSelectedPart(selectedPart: string): void {
@@ -732,8 +748,16 @@ window.addEventListener('beforeunload', () => {
 function initializeSettingsPanel(): void {
   settingsConfidenceEl.value = String(overlaySettings.confidenceThreshold);
   settingsTrailEl.value = String(overlaySettings.trailMs / 1000);
+  settingsShowNoteNamesEl.checked = showNoteNames;
   updateSettingsLabels();
 }
+
+settingsShowNoteNamesEl.addEventListener('change', () => {
+  showNoteNames = settingsShowNoteNamesEl.checked;
+  if (lastDetectedMidi !== null) {
+    updatePitchReadout(lastDetectedMidi);
+  }
+});
 
 setTransportEnabled(false);
 tempoLabelEl.textContent = `${tempoSliderEl.value}%`;

--- a/frontend/src/pitch/note.test.ts
+++ b/frontend/src/pitch/note.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { midiToFrequencyHz, midiToNoteName } from './note';
+
+describe('midiToFrequencyHz', () => {
+  it('maps A4 (69) to 440 Hz', () => {
+    expect(midiToFrequencyHz(69)).toBeCloseTo(440, 6);
+  });
+
+  it('maps C4 (60) to 261.63 Hz', () => {
+    expect(midiToFrequencyHz(60)).toBeCloseTo(261.63, 2);
+  });
+});
+
+describe('midiToNoteName', () => {
+  it('converts core reference notes', () => {
+    expect(midiToNoteName(69)).toBe('A4');
+    expect(midiToNoteName(60)).toBe('C4');
+    expect(midiToNoteName(52)).toBe('E3');
+    expect(midiToNoteName(55)).toBe('G3');
+  });
+
+  it('rounds fractional midi values to nearest note', () => {
+    expect(midiToNoteName(68.51)).toBe('A4');
+    expect(midiToNoteName(68.49)).toBe('G#4');
+  });
+});

--- a/frontend/src/pitch/note.ts
+++ b/frontend/src/pitch/note.ts
@@ -1,0 +1,15 @@
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'] as const;
+
+/** Convert a MIDI note number to frequency in Hz (A4 = 440 Hz). */
+export function midiToFrequencyHz(midi: number): number {
+  return 440 * Math.pow(2, (midi - 69) / 12);
+}
+
+/** Convert a (possibly fractional) MIDI value to the nearest note name (e.g. C4). */
+export function midiToNoteName(midi: number): string {
+  const roundedMidi = Math.round(midi);
+  const normalizedIndex = ((roundedMidi % 12) + 12) % 12;
+  const note = NOTE_NAMES[normalizedIndex];
+  const octave = Math.floor(roundedMidi / 12) - 1;
+  return `${note}${octave}`;
+}


### PR DESCRIPTION
### Motivation

- Provide singers with an optional, human-friendly note name (e.g. `A4`, `C4`) alongside the detected pitch to make pitch feedback more useful. 
- Surface the live pitch value in the toolbar so users can see frequency and (optionally) the nearest note name in real time.

### Description

- Add `frontend/src/pitch/note.ts` exposing `midiToFrequencyHz` and `midiToNoteName` to convert MIDI values to Hz and nearest note names. 
- Add unit tests in `frontend/src/pitch/note.test.ts` covering reference mappings (`A4`, `C4`) and fractional-MIDI rounding behaviour. 
- Add a live toolbar readout and a new Settings checkbox by updating `frontend/index.html` and wire the UI logic in `frontend/src/main.ts` to update the readout from incoming pitch frames and respect the `Show note names` toggle. 
- Minor cleanup in `main.ts` to remove a duplicate transport import while wiring the new feature.

### Testing

- Ran `npm test` in `frontend/`; all tests passed (`57` tests across `8` files) and the new unit tests succeeded. 
- Ran `npm run build` in `frontend/`; production build completed successfully. 
- Performed an automated Playwright smoke-check to capture the settings panel and new pitch readout, producing an artifact at `browser:/tmp/codex_browser_invocations/f9dc5c95c9bb3437/artifacts/artifacts/issue-62-note-name-toggle.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44bfb41088327a98338d855e6f5f6)