### PR TITLE
Add optional note-name display for detected pitch

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -141,6 +141,13 @@
       margin-left: 4px;
     }
 
+    #pitch-readout {
+      font-size: 0.8rem;
+      color: #c5d9ff;
+      margin-left: 8px;
+      min-width: 120px;
+    }
+
     /* ── Main content area ── */
     main {
       flex: 1;
@@ -367,6 +374,7 @@
     <button id="btn-browse" class="transport-btn">Browse…</button>
     <button id="btn-settings" class="transport-btn">⚙ Settings</button>
 
+    <span id="pitch-readout" aria-live="polite">Detected: —</span>
     <span id="score-info"></span>
   </div>
 
@@ -384,6 +392,13 @@
     <div class="settings-row">
       <label for="settings-trail">Pitch trail length: <span id="settings-trail-label">2.0s</span></label>
       <input id="settings-trail" type="range" min="0.5" max="5" step="0.5" value="2" />
+    </div>
+
+    <div class="settings-row">
+      <label>
+        <input id="settings-show-note-names" type="checkbox" />
+        Show note names in pitch readout
+      </label>
     </div>
 
 

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -18,6 +18,7 @@ import { SoundfontLoader } from './playback/soundfont';
 import { PlaybackEngine } from './playback/engine';
 import { MIN_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from './pitch/overlay';
 import { parsePitchFrame, reconnectDelayMs } from './pitch/socket';
+import { midiToFrequency, midiToNoteName } from './pitch/note-name';
 import { getVisiblePartOptions } from './part-options';
 import { elapsedToBeat } from './score/timing';
 import { beatToMs, startPlayback, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose } from './transport/controls';
@@ -46,12 +47,14 @@ const errorBannerEl   = document.getElementById('error-banner') as HTMLDivElemen
 const showAccompanimentEl = document.getElementById('show-accompaniment') as HTMLInputElement;
 const transposeSelectEl = document.getElementById('transpose-select') as HTMLSelectElement;
 const btnSettings = document.getElementById('btn-settings') as HTMLButtonElement;
+const pitchReadoutEl = document.getElementById('pitch-readout') as HTMLSpanElement;
 const settingsPanelEl = document.getElementById('settings-panel') as HTMLDivElement;
 const settingsDeviceEl = document.getElementById('settings-device') as HTMLSelectElement;
 const settingsConfidenceEl = document.getElementById('settings-confidence') as HTMLInputElement;
 const settingsConfidenceLabelEl = document.getElementById('settings-confidence-label') as HTMLSpanElement;
 const settingsTrailEl = document.getElementById('settings-trail') as HTMLInputElement;
 const settingsTrailLabelEl = document.getElementById('settings-trail-label') as HTMLSpanElement;
+const settingsShowNoteNamesEl = document.getElementById('settings-show-note-names') as HTMLInputElement;
 const settingsEngineEl = document.getElementById('settings-engine') as HTMLDivElement;
 const recordingEnabledEl = document.getElementById('recording-enabled') as HTMLInputElement;
 const btnRecordStart = document.getElementById('btn-record-start') as HTMLButtonElement;
@@ -80,6 +83,8 @@ let shouldReconnectPitchSocket = false;
 let pitchReconnectAttempts = 0;
 let cursorBeatSample: { beat: number; x: number } | null = null;
 let pxPerBeatEstimate = 0;
+let showNoteNames = false;
+let lastPitchFrame: { midi: number } | null = null;
 
 const overlaySettings: OverlaySettings = {
   confidenceThreshold: MIN_CONFIDENCE_THRESHOLD,
@@ -169,6 +174,8 @@ async function loadScore(file: File): Promise<void> {
   closePitchSocket();
   pitchOverlay?.destroy();
   pitchOverlay = null;
+  lastPitchFrame = null;
+  updatePitchReadout();
   scoreContainerEl.innerHTML = '';
 
   // Start soundfont loading in background (idempotent)
@@ -333,6 +340,24 @@ function closePitchSocket(): void {
   }
 }
 
+function updatePitchReadout(): void {
+  if (!lastPitchFrame) {
+    pitchReadoutEl.textContent = 'Detected: —';
+    return;
+  }
+
+  const hz = midiToFrequency(lastPitchFrame.midi);
+  const frequencyLabel = `${hz.toFixed(2)} Hz`;
+
+  if (!showNoteNames) {
+    pitchReadoutEl.textContent = `Detected: ${frequencyLabel}`;
+    return;
+  }
+
+  const noteName = midiToNoteName(lastPitchFrame.midi);
+  pitchReadoutEl.textContent = `Detected: ${frequencyLabel} → ${noteName}`;
+}
+
 function connectPitchSocket(): void {
   if (!pitchOverlay) return;
   shouldReconnectPitchSocket = true;
@@ -381,6 +406,9 @@ function connectPitchSocket(): void {
 
     const frame = parsePitchFrame(payload);
     if (!frame) return;
+
+    lastPitchFrame = { midi: frame.midi };
+    updatePitchReadout();
 
     pitchOverlay.pushFrame(
       frame,
@@ -530,6 +558,8 @@ btnPlay.addEventListener('click', async () => {
       cursor.stop();
       cursor.osmd.cursor.show();
       pitchOverlay?.clear();
+      lastPitchFrame = null;
+      updatePitchReadout();
     }
 
     engine.play(fromBeat);
@@ -560,6 +590,8 @@ btnStop.addEventListener('click', async () => {
     stopCursorRaf();
     cursor.stop();
     pitchOverlay?.clear();
+    lastPitchFrame = null;
+    updatePitchReadout();
     headphoneWarning.classList.add('hidden');
   } catch (err) {
     setStatus(`stop failed: ${String(err)}`, 'error');
@@ -579,6 +611,8 @@ btnRewind.addEventListener('click', async () => {
   stopCursorRaf();
   cursor.stop();
   cursor.osmd.cursor.show();
+  lastPitchFrame = null;
+  updatePitchReadout();
   headphoneWarning.classList.add('hidden');
 });
 
@@ -688,6 +722,11 @@ settingsTrailEl.addEventListener('input', () => {
   overlaySettings.trailMs = parseFloat(settingsTrailEl.value) * 1000;
   pitchOverlay?.applySettings(overlaySettings);
   updateSettingsLabels();
+});
+
+settingsShowNoteNamesEl.addEventListener('change', () => {
+  showNoteNames = settingsShowNoteNamesEl.checked;
+  updatePitchReadout();
 });
 
 recordingEnabledEl.addEventListener('change', () => {
@@ -818,7 +857,9 @@ window.addEventListener('beforeunload', () => {
 function initializeSettingsPanel(): void {
   settingsConfidenceEl.value = String(overlaySettings.confidenceThreshold);
   settingsTrailEl.value = String(overlaySettings.trailMs / 1000);
+  settingsShowNoteNamesEl.checked = showNoteNames;
   updateSettingsLabels();
+  updatePitchReadout();
 }
 
 setTransportEnabled(false);

--- a/frontend/src/pitch/note-name.test.ts
+++ b/frontend/src/pitch/note-name.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { midiToFrequency, midiToNoteName } from './note-name';
+
+describe('midiToFrequency', () => {
+  it('converts A4 MIDI to 440Hz', () => {
+    expect(midiToFrequency(69)).toBeCloseTo(440, 5);
+  });
+});
+
+describe('midiToNoteName', () => {
+  it('maps standard notes correctly', () => {
+    expect(midiToNoteName(69)).toBe('A4');
+    expect(midiToNoteName(60)).toBe('C4');
+    expect(midiToNoteName(55)).toBe('G3');
+  });
+
+  it('rounds fractional midi to nearest note', () => {
+    expect(midiToNoteName(63.49)).toBe('D#4');
+    expect(midiToNoteName(63.5)).toBe('E4');
+  });
+});

--- a/frontend/src/pitch/note-name.ts
+++ b/frontend/src/pitch/note-name.ts
@@ -1,0 +1,12 @@
+const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+
+export function midiToFrequency(midi: number): number {
+  return 440 * (2 ** ((midi - 69) / 12));
+}
+
+export function midiToNoteName(midi: number): string {
+  const nearestMidi = Math.round(midi);
+  const normalized = ((nearestMidi % 12) + 12) % 12;
+  const octave = Math.floor(nearestMidi / 12) - 1;
+  return `${NOTE_NAMES[normalized]}${octave}`;
+}


### PR DESCRIPTION
### Motivation
- Provide singers with a human-readable note name (e.g. `A4`) alongside the detected pitch to improve usability when practising, as requested in issue #62.

### Description
- Added a live pitch readout element in the toolbar (`#pitch-readout`) and a settings checkbox (`#settings-show-note-names`) to toggle note-name display in the readout.
- Implemented `midiToFrequency` and `midiToNoteName` helpers in `frontend/src/pitch/note-name.ts` to convert MIDI values to Hz and nearest note names, including correct octave calculation and rounding behavior.
- Updated `frontend/src/main.ts` to track the last received pitch frame, render the frequency and optional note name in real time, and clear/reset the readout on load/play/stop/rewind transitions to avoid stale values.
- Added unit tests `frontend/src/pitch/note-name.test.ts` to validate frequency conversion and note-name mapping (including fractional MIDI rounding), and minor styling for the readout in `frontend/index.html`.

### Testing
- Ran frontend unit tests with `npm test` and all tests passed: 9 test files, 63 tests (9 files passed, 63 tests passed).
- Built the frontend with `npm run build` successfully and produced the production bundle without errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b44d5bf0588327a3e8123ade1b8a7d)