### PR TITLE
feat(frontend): enable click-to-seek on rendered score

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -23,6 +23,7 @@ import { elapsedToBeat } from './score/timing';
 import { beatToMs, startPlayback, postPlayback, seekPlayback, setPlaybackTempo, setPlaybackTranspose } from './transport/controls';
 import { resolveSelectedDeviceId, type AudioInputDevice } from './audio/devices';
 import { PracticeRecorder } from './audio/recorder';
+import { beatFromClick, extractMeasureHitZones } from './score/click-seek';
 
 // ── DOM refs ──────────────────────────────────────────────────────────────────
 
@@ -317,6 +318,36 @@ function cursorXPosition(): number {
   const scoreRect = scoreContainerEl.getBoundingClientRect();
   const cursorRect = cursorEl.getBoundingClientRect();
   return cursorRect.left - scoreRect.left + scoreContainerEl.scrollLeft;
+}
+
+async function seekToClickedPosition(event: MouseEvent): Promise<void> {
+  if (!renderer || !engine || !cursor || !renderer.scoreModel) return;
+
+  const svg = scoreContainerEl.querySelector('svg');
+  if (!(svg instanceof SVGSVGElement)) return;
+
+  const ctm = svg.getScreenCTM();
+  if (!ctm) return;
+
+  const svgPoint = svg.createSVGPoint();
+  svgPoint.x = event.clientX;
+  svgPoint.y = event.clientY;
+  const local = svgPoint.matrixTransform(ctm.inverse());
+
+  const zones = extractMeasureHitZones(renderer.osmd);
+  const targetBeat = beatFromClick(zones, local.x, local.y);
+  if (targetBeat === null) return;
+
+  try {
+    await seekPlayback(beatToMs(targetBeat, renderer.scoreModel, engine.tempoMultiplier));
+  } catch (err) {
+    setStatus(`seek failed: ${String(err)}`, 'error');
+    console.error('Seek failed:', err);
+    return;
+  }
+
+  engine.seekToBeat(targetBeat);
+  cursor.seekToBeat(targetBeat);
 }
 
 function closePitchSocket(): void {
@@ -793,6 +824,10 @@ btnBrowse.addEventListener('click', () => fileInputEl.click());
 fileInputEl.addEventListener('change', () => {
   const file = fileInputEl.files?.[0];
   if (file) void loadScore(file);
+});
+
+scoreContainerEl.addEventListener('click', (event) => {
+  void seekToClickedPosition(event);
 });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/frontend/src/score/click-seek.test.ts
+++ b/frontend/src/score/click-seek.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest';
+import { beatFromClick, extractMeasureHitZones, type MeasureHitZone } from './click-seek';
+
+describe('beatFromClick', () => {
+  const zones: MeasureHitZone[] = [
+    { x: 0, y: 0, width: 100, height: 40, beatStart: 0, beatDuration: 4 },
+    { x: 120, y: 0, width: 100, height: 40, beatStart: 4, beatDuration: 4 },
+  ];
+
+  it('maps click position proportionally within the matching measure', () => {
+    const beat = beatFromClick(zones, 50, 20);
+    expect(beat).toBeCloseTo(2, 5);
+  });
+
+  it('chooses nearest measure when click is outside any hit zone', () => {
+    const beat = beatFromClick(zones, 240, 20);
+    // Clamped to measure end when clicking beyond right edge.
+    expect(beat).toBeCloseTo(8, 5);
+  });
+
+  it('returns null for empty zone list', () => {
+    expect(beatFromClick([], 10, 10)).toBeNull();
+  });
+});
+
+describe('extractMeasureHitZones', () => {
+  it('extracts beat ranges and geometry from OSMD-like measure structures', () => {
+    const osmdLike = {
+      GraphicSheet: {
+        MeasureList: [
+          [
+            {
+              boundingBox: {
+                absolutePosition: { x: 10, y: 20 },
+                size: {
+                  width: { realValue: 80 },
+                  height: { realValue: 50 },
+                },
+              },
+              parentSourceMeasure: {
+                AbsoluteTimestamp: { RealValue: 1.5 },
+                Duration: { RealValue: 1 },
+              },
+            },
+          ],
+        ],
+      },
+    };
+
+    const zones = extractMeasureHitZones(osmdLike);
+    expect(zones).toEqual([
+      { x: 10, y: 20, width: 80, height: 50, beatStart: 6, beatDuration: 4 },
+    ]);
+  });
+
+  it('returns empty list when shape is missing', () => {
+    expect(extractMeasureHitZones({})).toEqual([]);
+  });
+});

--- a/frontend/src/score/click-seek.ts
+++ b/frontend/src/score/click-seek.ts
@@ -1,0 +1,109 @@
+export interface MeasureHitZone {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  beatStart: number;
+  beatDuration: number;
+}
+
+function asFiniteNumber(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function getBoxDimension(box: Record<string, unknown>, key: string): number | null {
+  const direct = asFiniteNumber(box[key]);
+  if (direct !== null) return direct;
+
+  const nested = box[key];
+  if (nested && typeof nested === 'object') {
+    const maybeReal = asFiniteNumber((nested as Record<string, unknown>).realValue);
+    if (maybeReal !== null) return maybeReal;
+  }
+
+  return null;
+}
+
+export function extractMeasureHitZones(osmd: unknown): MeasureHitZone[] {
+  const graphicSheet = (osmd as { GraphicSheet?: unknown })?.GraphicSheet;
+  if (!graphicSheet || typeof graphicSheet !== 'object') return [];
+
+  const measureList = (graphicSheet as { MeasureList?: unknown }).MeasureList;
+  if (!Array.isArray(measureList)) return [];
+
+  const zones: MeasureHitZone[] = [];
+
+  for (const staffMeasures of measureList) {
+    if (!Array.isArray(staffMeasures)) continue;
+
+    for (const graphicalMeasure of staffMeasures) {
+      if (!graphicalMeasure || typeof graphicalMeasure !== 'object') continue;
+
+      const box = (graphicalMeasure as { boundingBox?: unknown }).boundingBox;
+      const sourceMeasure = (graphicalMeasure as { parentSourceMeasure?: unknown }).parentSourceMeasure;
+      if (!box || typeof box !== 'object' || !sourceMeasure || typeof sourceMeasure !== 'object') continue;
+
+      const absolute = (box as { absolutePosition?: unknown }).absolutePosition;
+      const size = (box as { size?: unknown }).size;
+      if (!absolute || typeof absolute !== 'object' || !size || typeof size !== 'object') continue;
+
+      const x = asFiniteNumber((absolute as Record<string, unknown>).x);
+      const y = asFiniteNumber((absolute as Record<string, unknown>).y);
+      const width = getBoxDimension(size as Record<string, unknown>, 'width');
+      const height = getBoxDimension(size as Record<string, unknown>, 'height');
+
+      const timestamp = (sourceMeasure as { AbsoluteTimestamp?: unknown }).AbsoluteTimestamp;
+      const duration = (sourceMeasure as { Duration?: unknown }).Duration;
+      const timestampReal = timestamp && typeof timestamp === 'object'
+        ? asFiniteNumber((timestamp as Record<string, unknown>).RealValue)
+        : null;
+      const durationReal = duration && typeof duration === 'object'
+        ? asFiniteNumber((duration as Record<string, unknown>).RealValue)
+        : null;
+
+      if (x === null || y === null || width === null || height === null || width <= 0 || height <= 0) continue;
+      if (timestampReal === null || durationReal === null || durationReal <= 0) continue;
+
+      zones.push({
+        x,
+        y,
+        width,
+        height,
+        beatStart: timestampReal * 4,
+        beatDuration: durationReal * 4,
+      });
+    }
+  }
+
+  return zones;
+}
+
+export function beatFromClick(zones: MeasureHitZone[], clickX: number, clickY: number): number | null {
+  if (zones.length === 0) return null;
+
+  const containing = zones.filter((zone) => (
+    clickX >= zone.x
+    && clickX <= zone.x + zone.width
+    && clickY >= zone.y
+    && clickY <= zone.y + zone.height
+  ));
+
+  const pool = containing.length > 0 ? containing : zones;
+
+  let bestZone = pool[0];
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const zone of pool) {
+    const cx = zone.x + zone.width / 2;
+    const cy = zone.y + zone.height / 2;
+    const dx = clickX - cx;
+    const dy = clickY - cy;
+    const distance = (dx * dx) + (dy * dy);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestZone = zone;
+    }
+  }
+
+  const relativeX = Math.max(0, Math.min(1, (clickX - bestZone.x) / bestZone.width));
+  return bestZone.beatStart + (bestZone.beatDuration * relativeX);
+}


### PR DESCRIPTION
### Motivation
- Provide the common music-player UX of clicking a note/measure to jump the playback cursor so users can start practice from any point (implements issue #70).

### Description
- Add `frontend/src/score/click-seek.ts` which extracts per-measure geometry from OSMD's `GraphicSheet.MeasureList` and maps click coordinates to a target beat via horizontal interpolation inside a measure.
- Wire a click handler in `frontend/src/main.ts` that converts window coordinates to SVG-local coordinates, computes the target beat with `beatFromClick`, calls the backend seek via `seekPlayback`, and then updates `PlaybackEngine.seekToBeat` and `ScoreCursor.seekToBeat` so playback and cursor remain in sync.
- Add focused unit tests in `frontend/src/score/click-seek.test.ts` to validate hit-zone extraction and click→beat mapping and ensure the change is covered by the frontend build.

### Testing
- Ran `npm test -- click-seek` and `npm test -- click-seek timing` and all tests passed (total tests in these suites passed).
- Ran `npm run build` for the frontend and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b472bd042083279262d8ab3dc9cecc)