### PR TITLE
Fix soundfont loader JSON parsing for MIDI.js assets

### DIFF
--- a/frontend/src/playback/soundfont.test.ts
+++ b/frontend/src/playback/soundfont.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest';
+import { SoundfontLoader } from './soundfont';
+
+describe('SoundfontLoader.parseNoteMap', () => {
+  it('parses MIDI.js assignment with trailing non-JSON content', () => {
+    const js = [
+      'MIDI.Soundfont.acoustic_grand_piano = {"A0":"data:audio/mp3;base64,QQ=="};',
+      '//# sourceMappingURL=acoustic_grand_piano.js.map',
+    ].join('\n');
+
+    expect(SoundfontLoader.parseNoteMap(js)).toEqual({
+      A0: 'data:audio/mp3;base64,QQ==',
+    });
+  });
+
+  it('throws when no soundfont assignment is present', () => {
+    expect(() => SoundfontLoader.parseNoteMap('<!doctype html>403 Forbidden')).toThrow(
+      'Could not parse soundfont JS: no JSON object found',
+    );
+  });
+});

--- a/frontend/src/playback/soundfont.ts
+++ b/frontend/src/playback/soundfont.ts
@@ -18,6 +18,9 @@
 const SOUNDFONT_URL =
   'https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/acoustic_grand_piano-mp3.js';
 
+const SOUNDFONT_ASSIGNMENT_RE =
+  /MIDI\.Soundfont\.[A-Za-z0-9_]+\s*=\s*(\{[\s\S]*?\})\s*;?/;
+
 // Flat-notation names matching the gleitz soundfont key names exactly.
 // MIDI 0 = C-1, MIDI 60 = C4, MIDI 69 = A4.
 const NOTE_NAMES = ['C', 'Db', 'D', 'Eb', 'E', 'F', 'Gb', 'G', 'Ab', 'A', 'Bb', 'B'] as const;
@@ -67,9 +70,7 @@ export class SoundfontLoader {
 
     // 2. Extract the embedded JSON object
     // File structure: MIDI.Soundfont.acoustic_grand_piano = { "A0": "data:…", … }
-    const match = js.match(/=\s*(\{[\s\S]*\})/);
-    if (!match) throw new Error('Could not parse soundfont JS: no JSON object found');
-    const noteMap = JSON.parse(match[1]) as Record<string, string>;
+    const noteMap = SoundfontLoader.parseNoteMap(js);
 
     // 3. Decode all samples concurrently
     const entries = Object.entries(noteMap);
@@ -136,4 +137,9 @@ export class SoundfontLoader {
   // Exposed for tests
   static midiToNoteName = midiToNoteName;
   static noteNameToMidi = noteNameToMidi;
+  static parseNoteMap(js: string): Record<string, string> {
+    const match = js.match(SOUNDFONT_ASSIGNMENT_RE);
+    if (!match) throw new Error('Could not parse soundfont JS: no JSON object found');
+    return JSON.parse(match[1]) as Record<string, string>;
+  }
 }


### PR DESCRIPTION
### Motivation
- The soundfont loader was extracting JSON with a greedy pattern and calling `JSON.parse` on content that could include trailing non-JSON text (for example source-map comments) or an HTML error page, producing a `SyntaxError` and forcing the app into synth fallback audio.

### Description
- Add a precise, non-greedy regex `SOUNDFONT_ASSIGNMENT_RE` that targets `MIDI.Soundfont.<instrument> = { ... }` assignments. 
- Introduce `SoundfontLoader.parseNoteMap(js: string)` to encapsulate extraction and parsing of the embedded note map. 
- Update `SoundfontLoader.load()` to use `parseNoteMap()` instead of an inline greedy match. 
- Add unit tests in `frontend/src/playback/soundfont.test.ts` that verify parsing succeeds with trailing non-JSON content and that the parser throws on non-soundfont responses.

### Testing
- Ran `npm test -- --run src/playback/soundfont.test.ts src/playback/engine.test.ts` and all tests passed (2 tests in `soundfont.test.ts` and 19 tests in `engine.test.ts`, total 21 tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b474deeeb48327988c53eb280c51af)