### PR TITLE
Fix score notation not updating on transpose changes

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -211,6 +211,7 @@ async function loadScore(file: File): Promise<void> {
       parseFloat(tempoSliderEl.value) / 100,
     );
 
+    renderer.applyVisualTranspose(getTransposeSemitones());
     cursor = new ScoreCursor(renderer.osmd, model);
     renderer.setHighlightedPart(selectedPart);
     pitchOverlay = new PitchOverlay(scoreContainerEl, model, selectedPart, overlaySettings);
@@ -658,6 +659,7 @@ tempoSliderEl.addEventListener('change', async () => {
 transposeSelectEl.addEventListener('change', async () => {
   const semitones = getTransposeSemitones();
   engine?.setTransposeSemitones(semitones);
+  renderer?.applyVisualTranspose(semitones);
   try {
     await setPlaybackTranspose(semitones);
   } catch (err) {

--- a/frontend/src/score/renderer.test.ts
+++ b/frontend/src/score/renderer.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  renderMock: vi.fn(),
+  loadMock: vi.fn(async (_file: Blob) => undefined),
+  updateGraphicMock: vi.fn(),
+}));
+
+vi.mock('opensheetmusicdisplay', () => ({
+  OpenSheetMusicDisplay: class {
+    Sheet = { Transpose: 0 };
+
+    constructor(_container: HTMLElement, _options: unknown) {}
+
+    async load(file: Blob): Promise<void> {
+      await mocks.loadMock(file);
+    }
+
+    updateGraphic(): void {
+      mocks.updateGraphicMock();
+    }
+
+    render(): void {
+      mocks.renderMock();
+    }
+  },
+}));
+
+import { ScoreRenderer } from './renderer';
+
+describe('ScoreRenderer visual transpose', () => {
+  beforeEach(() => {
+    mocks.renderMock.mockClear();
+    mocks.loadMock.mockClear();
+    mocks.updateGraphicMock.mockClear();
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => ({
+        ok: true,
+        json: async () => ({
+          title: 'Test',
+          parts: ['PART I'],
+          notes: [],
+          tempo_marks: [{ beat: 0, bpm: 120 }],
+          time_signatures: [{ beat: 0, numerator: 4, denominator: 4 }],
+          total_beats: 1,
+        }),
+      })),
+    );
+  });
+
+  it('re-renders notation when transposition changes after load', async () => {
+    const renderer = new ScoreRenderer({} as HTMLElement);
+    await renderer.load(new Blob(['<score-partwise/>'], { type: 'application/xml' }) as File);
+
+    expect(mocks.renderMock).toHaveBeenCalledTimes(1);
+
+    renderer.applyVisualTranspose(3);
+
+    expect(renderer.osmd.Sheet.Transpose).toBe(3);
+    expect(mocks.updateGraphicMock).toHaveBeenCalledTimes(1);
+    expect(mocks.renderMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('stores transpose before load and applies it once rendered', async () => {
+    const renderer = new ScoreRenderer({} as HTMLElement);
+    renderer.applyVisualTranspose(-5);
+
+    expect(mocks.updateGraphicMock).not.toHaveBeenCalled();
+
+    await renderer.load(new Blob(['<score-partwise/>'], { type: 'application/xml' }) as File);
+
+    expect(renderer.osmd.Sheet.Transpose).toBe(-5);
+    expect(mocks.updateGraphicMock).toHaveBeenCalledTimes(1);
+    expect(mocks.renderMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/frontend/src/score/renderer.ts
+++ b/frontend/src/score/renderer.ts
@@ -43,6 +43,7 @@ export interface ScoreModel {
 export class ScoreRenderer {
   readonly osmd: OpenSheetMusicDisplay;
   private _loaded = false;
+  private visualTransposeSemitones = 0;
   public scoreModel: ScoreModel | null = null;
 
   constructor(container: HTMLElement) {
@@ -96,6 +97,7 @@ export class ScoreRenderer {
     // Commit state only after both phases succeed
     this.scoreModel = model;
     this._loaded = true;
+    this.applyVisualTranspose(this.visualTransposeSemitones);
     return model;
   }
 
@@ -113,5 +115,19 @@ export class ScoreRenderer {
    */
   setHighlightedPart(_partName: string): void {
     // Intentionally a no-op due to current OSMD public API limitations.
+  }
+
+  /** Apply visual transposition to score notation and re-render the sheet. */
+  applyVisualTranspose(semitones: number): void {
+    const roundedSemitones = Math.round(semitones);
+    const clampedSemitones = Math.max(-24, Math.min(24, roundedSemitones));
+    this.visualTransposeSemitones = clampedSemitones;
+
+    if (!this._loaded || !this.osmd.Sheet) return;
+    if (this.osmd.Sheet.Transpose === clampedSemitones) return;
+
+    this.osmd.Sheet.Transpose = clampedSemitones;
+    this.osmd.updateGraphic();
+    this.osmd.render();
   }
 }


### PR DESCRIPTION
### Motivation
- The transpose control only affected audio playback but did not update the visual OSMD score, causing key signature and note positions to remain unchanged.
- The change aims to support visual transposition (useful for transposing instruments or singers) and to persist a transpose chosen before the score finishes loading.

### Description
- Add `visualTransposeSemitones` and `applyVisualTranspose(semitones)` to `ScoreRenderer` to set `osmd.Sheet.Transpose`, call `updateGraphic()`, and re-render the sheet when needed (`frontend/src/score/renderer.ts`).
- Persist a pending transpose value and apply it immediately after the score finishes loading so pre-load selections take effect (`ScoreRenderer.load`).
- Wire the UI and load flow to update visual notation as well as playback by calling `renderer.applyVisualTranspose(...)` on load and when the transpose selector changes (`frontend/src/main.ts`).
- Add unit tests covering post-load transpose updates and pre-load transpose persistence (`frontend/src/score/renderer.test.ts`).

### Testing
- Ran the new renderer tests directly with `cd frontend && npm test -- --run src/score/renderer.test.ts` and they passed.
- Ran the full frontend test suite with `cd frontend && npm test` and all tests passed (`66 passed`).
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b474f2244c8327be264d0442dd34db)