### PR TITLE
fix: clear pitch graph history on play/stop/rewind

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -651,6 +651,7 @@ btnPlay.addEventListener('click', async () => {
       cursor.stop();
       cursor.osmd.cursor.show();
       pitchOverlay?.clear();
+      pitchGraph?.clear();
       pitchGraphNowSec = 0;
       lastPitchFrame = null;
       updatePitchReadout();
@@ -684,6 +685,8 @@ btnStop.addEventListener('click', async () => {
     stopCursorRaf();
     cursor.stop();
     pitchOverlay?.clear();
+    pitchGraph?.clear();
+    pitchGraphNowSec = 0;
     lastPitchFrame = null;
     updatePitchReadout();
     headphoneWarning.classList.add('hidden');
@@ -705,6 +708,9 @@ btnRewind.addEventListener('click', async () => {
   stopCursorRaf();
   cursor.stop();
   cursor.osmd.cursor.show();
+  pitchOverlay?.clear();
+  pitchGraph?.clear();
+  pitchGraphNowSec = 0;
   lastPitchFrame = null;
   updatePitchReadout();
   headphoneWarning.classList.add('hidden');

--- a/frontend/src/pitch/graph.ts
+++ b/frontend/src/pitch/graph.ts
@@ -84,7 +84,6 @@ export class PitchGraphCanvas {
   }
 
   pushFrame(frame: PitchFrame, expectedMidi: number | null): void {
-    const tSec = frame.t / 1000;
     this.samples.push({
       tSec: frame.t / 1000,
       midi: frame.midi,


### PR DESCRIPTION
### Motivation
- Users reported "double"/overlaid pitch traces because the graph retained samples between transport restarts, so each new run drew on top of prior history.

### Description
- Clear the pitch graph when starting playback from the beginning by calling `pitchGraph?.clear()` on fresh Play so new runs start with an empty graph.
- Clear the pitch graph and reset the graph timeline by setting `pitchGraphNowSec = 0` on Stop and Rewind so the rolling window does not carry state across runs.
- Minor cleanup in `PitchGraphCanvas.pushFrame()` by removing an unused local variable (`tSec`) to satisfy the build and keep code tidy.

### Testing
- Ran the frontend unit test suite with `cd frontend && npm run test -- --run`, which passed: 14 test files, 85 tests (all green). 
- Performed a production build with `cd frontend && npm run build`, which completed successfully. 
- Launched the dev server and captured a UI screenshot for manual verification of the updated graph behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a4008a9c8327889534f896b05777)