### PR TITLE
fix: keep pitch graph clock monotonic during render loop

### DIFF
--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -438,18 +438,20 @@ function startPitchGraphLoop(): void {
   if (pitchGraphRafId !== null) return;
 
   const tick = (): void => {
-    const playbackSec = playbackElapsedSec();
-    if (playbackSec !== null) {
-      pitchGraphNowSec = playbackSec;
-    }
-    pitchGraph?.tick(pitchGraphNowSec);
-
     if (syntheticModeEnabled && engine?.playing) {
       const elapsedSec = Math.max(0, engine.ctx.currentTime - engine.startAudioTime);
       const elapsedMs = elapsedSec * 1000;
       const expectedMidi = expectedMidiForFrame(elapsedMs);
       handleIncomingPitchFrame(syntheticPitchFrameAt(elapsedSec, expectedMidi));
     }
+
+    const playbackSec = playbackElapsedSec();
+    if (playbackSec !== null) {
+      // Keep graph time monotonic so frame-timestamp updates never get pulled
+      // backwards by slightly lagging playback clock updates.
+      pitchGraphNowSec = Math.max(pitchGraphNowSec, playbackSec);
+    }
+    pitchGraph?.tick(pitchGraphNowSec);
 
     pitchGraphRafId = requestAnimationFrame(tick);
   };


### PR DESCRIPTION
### Motivation
- Users reported the pitch graph trace collapsing at the right edge and incorrect red/blue continuity due to a timeline mismatch between synthetic/frame timestamps and the RAF tick clock in `startPitchGraphLoop`.

### Description
- Reordered the RAF loop to ingest synthetic frames before ticking the graph and made the graph clock monotonic by updating `pitchGraphNowSec` with `Math.max(pitchGraphNowSec, playbackSec)` so `handleIncomingPitchFrame` and `tick()` share a consistent timeline (`frontend/src/main.ts`).

### Testing
- Ran the frontend unit test suite with `cd frontend && npm run test -- --run`, which passed (14 test files, 85 tests, all green).  
- Performed a production build with `cd frontend && npm run build`, which completed successfully.  
- Launched the dev server and captured a UI screenshot for manual verification (`vite dev` + Playwright screenshot).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b4a72db0b88327b71b5b67174209d3)