### PR TITLE
Toggle Pause button to Resume and sync transport state (fix #104)

### DIFF
--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -15,7 +15,7 @@
  * services/cursor-projection.ts so pitch-overlay can read it without
  * importing from this feature.
  */
-import { onScoreCleared, getSession } from '../../services/score-session';
+import { onScoreCleared, onScoreLoaded, getSession } from '../../services/score-session';
 import { setStatus } from '../../services/backend';
 import { recordBeatSample, resetProjection, getCursorX } from '../../services/cursor-projection';
 import { beatToMs, postPlayback, startPlayback, seekPlayback } from '../../transport/controls';
@@ -85,7 +85,29 @@ function mount(_slot: HTMLElement): void {
   const headphoneWarning = document.getElementById('headphone-warning') as HTMLDivElement;
   const warningDismiss   = document.getElementById('warning-dismiss')   as HTMLButtonElement;
 
-  onScoreCleared(() => { stopCursorRaf(); });
+  function syncPauseButton(): void {
+    const session = getSession();
+    if (!session) {
+      btnPause.disabled = true;
+      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      return;
+    }
+    if (session.engine.state === 'playing') {
+      btnPause.disabled = false;
+      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      return;
+    }
+    if (session.engine.state === 'paused') {
+      btnPause.disabled = false;
+      btnPause.innerHTML = '&#9654; Resume';
+      return;
+    }
+    btnPause.disabled = true;
+    btnPause.innerHTML = '&#9646;&#9646; Pause';
+  }
+
+  onScoreLoaded(() => { syncPauseButton(); });
+  onScoreCleared(() => { stopCursorRaf(); syncPauseButton(); });
 
   btnPlay.addEventListener('click', async () => {
     const session = getSession();
@@ -104,6 +126,7 @@ function mount(_slot: HTMLElement): void {
       }
       engine.play(fromBeat);
       startCursorRaf();
+      syncPauseButton();
     } catch (err) {
       setStatus(`playback start failed: ${String(err)}`, 'error');
       console.error('Play failed:', err);
@@ -113,10 +136,18 @@ function mount(_slot: HTMLElement): void {
   btnPause.addEventListener('click', async () => {
     const session = getSession();
     if (!session) return;
+    const { engine } = session;
     try {
-      await postPlayback('/playback/pause');
-      session.engine.pause();
-      stopCursorRaf();
+      if (engine.state === 'playing') {
+        await postPlayback('/playback/pause');
+        engine.pause();
+        stopCursorRaf();
+      } else if (engine.state === 'paused') {
+        await postPlayback('/playback/resume');
+        engine.play(engine.startBeat);
+        startCursorRaf();
+      }
+      syncPauseButton();
     } catch (err) {
       setStatus(`pause failed: ${String(err)}`, 'error');
       console.error('Pause failed:', err);
@@ -132,6 +163,7 @@ function mount(_slot: HTMLElement): void {
       stopCursorRaf();
       session.cursor.stop();
       headphoneWarning.classList.add('hidden');
+      syncPauseButton();
     } catch (err) {
       setStatus(`stop failed: ${String(err)}`, 'error');
       console.error('Stop failed:', err);
@@ -150,9 +182,11 @@ function mount(_slot: HTMLElement): void {
     session.cursor.stop();
     session.cursor.osmd.cursor.show();
     headphoneWarning.classList.add('hidden');
+    syncPauseButton();
   });
 
   warningDismiss.addEventListener('click', () => { headphoneWarning.classList.add('hidden'); });
+  syncPauseButton();
 
   window.addEventListener('keydown', (e) => {
     if (e.repeat) return;

--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -62,7 +62,12 @@ function mount(slot: HTMLElement): void {
     for (const id of ids) {
       const el = document.getElementById(id) as
         HTMLButtonElement | HTMLInputElement | HTMLSelectElement | null;
-      if (el) el.disabled = !enabled;
+      if (!el) continue;
+      if (id === 'btn-pause') {
+        el.disabled = true;
+        continue;
+      }
+      el.disabled = !enabled;
     }
   }
 


### PR DESCRIPTION
### Motivation
- Make the transport Pause button behave as a true toggle: when playback is paused it should show `Resume` and continue from the paused beat, and Pause must be disabled when playback is not possible (matches issue #104). 

### Description
- Add a `syncPauseButton()` helper in `frontend/src/features/playback/index.ts` to update the `#btn-pause` label and enabled state based on `engine.state` and call it after play/pause/stop/rewind actions and on score lifecycle events (`onScoreLoaded`/`onScoreCleared`).
- Change the `#btn-pause` click handler to toggle behavior: if `engine.state === 'playing'` it sends `/playback/pause` and pauses the engine, while if `engine.state === 'paused'` it sends `/playback/resume` and restarts playback from `engine.startBeat`.
- Ensure the Play handler resumes correctly when starting from paused state and keep the cursor RAF behavior in sync by starting/stopping it where appropriate.
- Prevent the score loader from enabling `btn-pause` prematurely by updating `setTransportEnabled` in `frontend/src/features/score-loader/index.ts` so `btn-pause` remains disabled until the playback feature explicitly enables it.

### Testing
- Ran `npm test` in `frontend/` and all test files passed: `14 passed`, `90 tests` (success).
- Launched the dev server with `npm run dev` and verified the UI started and produced a screenshot showing the pause button disabled on initial load (dev server started successfully). 
- Observed expected Vite proxy warnings during the local UI session due to the backend not running, which did not affect UI verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55358a1f08327965e3b22cd9b8195)