### PR TITLE
Add PitchInterpreter with median filter, onset settling, and green hysteresis (issue #78)

### DIFF
--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -16,7 +16,7 @@
  * playback feature) to preserve feature isolation.
  */
 import { onScoreLoaded, onScoreCleared, getSession } from '../../services/score-session';
-import { setStatus, showErrorBanner } from '../../services/backend';
+import { showErrorBanner } from '../../services/backend';
 import { getFrameXPosition } from '../../services/cursor-projection';
 import { MIN_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from '../../pitch/overlay';
 import { PitchGraphCanvas } from '../../pitch/graph';

--- a/frontend/src/pitch/interpretation.test.ts
+++ b/frontend/src/pitch/interpretation.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from 'vitest';
+import {
+  createPitchInterpreter,
+  GREEN_ENTRY_CENTS,
+  GREEN_EXIT_CENTS,
+  MEDIAN_FILTER_FRAMES,
+  ONSET_SETTLE_MS,
+  noteKey,
+} from './interpretation';
+
+describe('PitchInterpreter', () => {
+  const expectedMidi = 60;
+  const expectedNoteKey = noteKey(0, expectedMidi, 'S');
+
+  it('stabilizes pitch output with median filter and suppresses isolated octave spikes', () => {
+    const interpreter = createPitchInterpreter();
+    const out: number[] = [];
+    const input = [60, 60.02, 60.03, 72, 59.99, 60.01, 60.04];
+
+    input.forEach((midi, idx) => {
+      const frame = interpreter.processFrame({
+        t: ONSET_SETTLE_MS + idx * 20,
+        midi,
+        conf: 0.9,
+        expectedMidi,
+        expectedNoteKey,
+        confidenceThreshold: 0.6,
+      });
+      out.push(frame.filteredMidi);
+    });
+
+    expect(out[3]).toBeLessThan(61);
+    expect(out[out.length - 1]).toBeGreaterThan(59.9);
+    expect(out[out.length - 1]).toBeLessThan(60.1);
+  });
+
+  it('uses grey during onset settling, then resumes grading', () => {
+    const interpreter = createPitchInterpreter();
+
+    const first = interpreter.processFrame({ t: 0, midi: 60, conf: 0.95, expectedMidi, expectedNoteKey, confidenceThreshold: 0.6 });
+    const second = interpreter.processFrame({ t: ONSET_SETTLE_MS - 1, midi: 60, conf: 0.95, expectedMidi, expectedNoteKey, confidenceThreshold: 0.6 });
+    const third = interpreter.processFrame({ t: ONSET_SETTLE_MS, midi: 60, conf: 0.95, expectedMidi, expectedNoteKey, confidenceThreshold: 0.6 });
+
+    expect(first.color).toBe('grey');
+    expect(second.color).toBe('grey');
+    expect(third.color).toBe('green');
+  });
+
+  it('applies green hysteresis entry/exit thresholds', () => {
+    const interpreter = createPitchInterpreter();
+    interpreter.processFrame({
+      t: 0,
+      midi: expectedMidi + (GREEN_ENTRY_CENTS / 100) + 0.05,
+      conf: 0.95,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    });
+
+    const atAmber = interpreter.processFrame({
+      t: ONSET_SETTLE_MS,
+      midi: expectedMidi + (GREEN_ENTRY_CENTS / 100) + 0.05,
+      conf: 0.95,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    });
+
+    const enterGreen = Array.from({ length: MEDIAN_FILTER_FRAMES }).map((_, idx) => interpreter.processFrame({
+      t: ONSET_SETTLE_MS + 20 + idx * 20,
+      midi: expectedMidi,
+      conf: 0.95,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    }));
+
+    const stayGreen = interpreter.processFrame({
+      t: ONSET_SETTLE_MS + 140,
+      midi: expectedMidi + (GREEN_EXIT_CENTS / 100),
+      conf: 0.95,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    });
+
+    const exitGreen = Array.from({ length: MEDIAN_FILTER_FRAMES }).map((_, idx) => interpreter.processFrame({
+      t: ONSET_SETTLE_MS + 160 + idx * 20,
+      midi: expectedMidi + (GREEN_EXIT_CENTS / 100) + 0.1,
+      conf: 0.95,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    }));
+
+    expect(atAmber.color).toBe('amber');
+    expect(enterGreen.at(-1)?.color).toBe('green');
+    expect(stayGreen.color).toBe('green');
+    expect(exitGreen.at(-1)?.color).toBe('amber');
+  });
+
+  it('retains voiced history through low-confidence frames and resets explicitly', () => {
+    const interpreter = createPitchInterpreter();
+    const inputs = [60, 60.02, 59.98, 60.01, 60.03];
+
+    inputs.forEach((midi, idx) => {
+      interpreter.processFrame({
+        t: ONSET_SETTLE_MS + idx * 15,
+        midi,
+        conf: 0.9,
+        expectedMidi,
+        expectedNoteKey,
+        confidenceThreshold: 0.6,
+      });
+    });
+
+    const lowConf = interpreter.processFrame({
+      t: ONSET_SETTLE_MS + 100,
+      midi: 62,
+      conf: 0.3,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    });
+    expect(lowConf.color).toBe('grey');
+    expect(lowConf.filteredMidi).toBeGreaterThan(59.95);
+    expect(lowConf.filteredMidi).toBeLessThan(60.05);
+
+    interpreter.reset();
+    const afterReset = interpreter.processFrame({
+      t: ONSET_SETTLE_MS + 120,
+      midi: 62,
+      conf: 0.9,
+      expectedMidi,
+      expectedNoteKey,
+      confidenceThreshold: 0.6,
+    });
+
+    expect(afterReset.filteredMidi).toBe(62);
+    expect(MEDIAN_FILTER_FRAMES).toBe(5);
+  });
+});

--- a/frontend/src/pitch/interpretation.ts
+++ b/frontend/src/pitch/interpretation.ts
@@ -1,0 +1,90 @@
+import type { DotColor } from './accuracy';
+
+export const MEDIAN_FILTER_FRAMES = 5;
+export const ONSET_SETTLE_MS = 150;
+export const GREEN_ENTRY_CENTS = 25;
+export const GREEN_EXIT_CENTS = 35;
+
+export interface InterpreterFrameInput {
+  t: number;
+  midi: number;
+  conf: number;
+  expectedMidi: number;
+  expectedNoteKey: string;
+  confidenceThreshold: number;
+}
+
+export interface InterpreterFrameOutput {
+  filteredMidi: number;
+  color: DotColor;
+}
+
+function centsError(sungMidi: number, expectedMidi: number): number {
+  return (sungMidi - expectedMidi) * 100;
+}
+
+function median(values: number[]): number {
+  if (values.length === 0) return Number.NaN;
+  const sorted = [...values].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 1) return sorted[mid];
+  return (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+export function noteKey(beatStart: number, midi: number, part: string): string {
+  return `${part}:${beatStart}:${midi}`;
+}
+
+export class PitchInterpreter {
+  private voicedMidis: number[] = [];
+  private currentNoteKey: string | null = null;
+  private noteOnsetMs = 0;
+  private inTuneLatched = false;
+
+  reset(): void {
+    this.voicedMidis = [];
+    this.currentNoteKey = null;
+    this.noteOnsetMs = 0;
+    this.inTuneLatched = false;
+  }
+
+  processFrame(input: InterpreterFrameInput): InterpreterFrameOutput {
+    const { t, midi, conf, expectedMidi, expectedNoteKey, confidenceThreshold } = input;
+
+    if (expectedNoteKey !== this.currentNoteKey) {
+      this.currentNoteKey = expectedNoteKey;
+      this.noteOnsetMs = t;
+      this.inTuneLatched = false;
+    }
+
+    if (conf >= confidenceThreshold) {
+      this.voicedMidis.push(midi);
+      if (this.voicedMidis.length > MEDIAN_FILTER_FRAMES) this.voicedMidis.shift();
+    }
+
+    const filteredMidi = this.voicedMidis.length > 0 ? median(this.voicedMidis) : midi;
+
+    if (conf < confidenceThreshold) {
+      return { filteredMidi, color: 'grey' };
+    }
+
+    if (t - this.noteOnsetMs < ONSET_SETTLE_MS) {
+      return { filteredMidi, color: 'grey' };
+    }
+
+    const absCents = Math.abs(centsError(filteredMidi, expectedMidi));
+    if (this.inTuneLatched) {
+      this.inTuneLatched = absCents <= GREEN_EXIT_CENTS;
+    } else {
+      this.inTuneLatched = absCents <= GREEN_ENTRY_CENTS;
+    }
+
+    if (this.inTuneLatched) return { filteredMidi, color: 'green' };
+    if (absCents <= 100) return { filteredMidi, color: 'amber' };
+    return { filteredMidi, color: 'red' };
+  }
+}
+
+export function createPitchInterpreter(): PitchInterpreter {
+  return new PitchInterpreter();
+}

--- a/frontend/src/pitch/overlay.ts
+++ b/frontend/src/pitch/overlay.ts
@@ -1,6 +1,7 @@
 import type { ScoreModel, NoteModel } from '../score/renderer';
 import { elapsedToBeat } from '../score/timing';
-import { classifyPitchColor, expectedNoteAtBeat, type DotColor } from './accuracy';
+import { expectedNoteAtBeat, type DotColor } from './accuracy';
+import { createPitchInterpreter, noteKey, type PitchInterpreter } from './interpretation';
 
 export const MIN_CONFIDENCE_THRESHOLD = 0.6;
 export const MAX_CONFIDENCE_THRESHOLD = 0.95;
@@ -55,6 +56,7 @@ export class PitchOverlay {
   private midiMax: number;
   private dots: Dot[] = [];
   private settings: OverlaySettings;
+  private readonly interpreter: PitchInterpreter;
 
   constructor(container: HTMLDivElement, model: ScoreModel, part: string, settings?: OverlaySettings) {
     this.container = container;
@@ -64,6 +66,7 @@ export class PitchOverlay {
     this.midiMax = 84;
     this.setPart(part);
     this.settings = normalizeOverlaySettings(settings ?? { confidenceThreshold: MIN_CONFIDENCE_THRESHOLD, trailMs: 2000 });
+    this.interpreter = createPitchInterpreter();
 
     this.canvas = document.createElement('canvas');
     this.canvas.style.position = 'absolute';
@@ -83,6 +86,7 @@ export class PitchOverlay {
 
   updatePart(part: string): void {
     this.setPart(part);
+    this.interpreter.reset();
     this.dots = [];
     this.redraw();
   }
@@ -100,6 +104,7 @@ export class PitchOverlay {
   }
 
   clear(): void {
+    this.interpreter.reset();
     this.dots = [];
     this.redraw();
   }
@@ -111,10 +116,17 @@ export class PitchOverlay {
     // No dot during rests or before the selected part's first note
     if (expected === null) return;
 
-    const color = classifyPitchColor(frame.midi, expected.midi, frame.conf, this.settings.confidenceThreshold);
-    const y = this.midiToY(frame.midi);
+    const interpreted = this.interpreter.processFrame({
+      t: frame.t,
+      midi: frame.midi,
+      conf: frame.conf,
+      expectedMidi: expected.midi,
+      expectedNoteKey: noteKey(expected.beat_start, expected.midi, expected.part),
+      confidenceThreshold: this.settings.confidenceThreshold,
+    });
+    const y = this.midiToY(interpreted.filteredMidi);
 
-    this.dots.push({ x: cursorX, y, color, wallMs: performance.now() });
+    this.dots.push({ x: cursorX, y, color: interpreted.color, wallMs: performance.now() });
     this.prune();
     this.redraw();
   }


### PR DESCRIPTION
### Motivation
- Stabilize rendered pitch and grading against vibrato, octave outliers, and transient note onsets as specified in issue #78.
- Move stateful pitch interpretation out of stateless utilities so overlay rendering can use a deterministic interpretation layer.

### Description
- Add `frontend/src/pitch/interpretation.ts` implementing `PitchInterpreter` with a 5-frame median filter, per-note 150ms onset settling, and green hysteresis (entry ≤25¢, exit ≤35¢), plus `reset()` and `noteKey()` helpers.
- Integrate the interpreter into `PitchOverlay.pushFrame()` so dot Y-position and color use interpreted output, and call `interpreter.reset()` from `clear()` and `updatePart()` in `frontend/src/pitch/overlay.ts`.
- Add deterministic unit tests in `frontend/src/pitch/interpretation.test.ts` covering vibrato/outlier suppression, onset settling, hysteresis entry/hold/exit, low-confidence behavior, and reset semantics.
- Remove an unused `setStatus` import in `frontend/src/features/pitch-overlay/index.ts` to keep TypeScript build clean.

### Testing
- Ran frontend unit tests with `cd frontend && npm test -- --run`; all tests passed (94/94).
- Built the frontend with `cd frontend && npm run build`; TypeScript compilation and Vite build succeeded (build completed, existing Vite chunk-size warning unchanged).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b55338fc0483278e2cae62ec2eb771)