### PR TITLE
docs: fix README licence to Apache-2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # sing-attune
 
 [![codecov](https://codecov.io/gh/leonarduk/sing-attune/branch/main/graph/badge.svg)](https://codecov.io/gh/leonarduk/sing-attune)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](LICENSE)
 
 **Practice your choir part. Hear the notes. Sing along. See your pitch in real time.**
 
@@ -203,4 +204,4 @@ Full build plan: [IMPLEMENTATION.md](IMPLEMENTATION.md)
 
 ## Licence
 
-Apache-2.0 — permissive open-source licensing with an explicit patent grant.
+Licensed under the [Apache License 2.0](LICENSE) — permissive open-source licensing with an explicit patent grant.


### PR DESCRIPTION
### Motivation
- Ensure README matches the project's declared `Apache-2.0` licensing (LICENSE and package manifests) and remove any remaining MIT wording to avoid contributor/user confusion.

### Description
- Add an `Apache-2.0` license badge near the top of `README.md` and update the `## Licence` section to explicitly reference the `Apache License 2.0` with a link to `LICENSE`.

### Testing
- Ran `rg "MIT" -n README.md docs issues || true` and confirmed no `MIT` matches were found, and ran `rg "License: Apache-2.0|Apache License 2.0|## Licence" -n README.md` to verify the new badge and section text are present, both checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5563f345c832789af19199b97055c)