### PR TITLE
Fix confidence threshold slider minimum and preserve 0.6 default

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -384,7 +384,7 @@
       </div>
       <div class="settings-row">
         <label for="settings-confidence">Confidence threshold: <span id="settings-confidence-label">0.60</span></label>
-        <input id="settings-confidence" type="range" min="0.6" max="0.95" step="0.05" value="0.6" />
+        <input id="settings-confidence" type="range" min="0" max="0.95" step="0.05" value="0.6" />
       </div>
       <div class="settings-row">
         <label for="settings-trail">Pitch trail length: <span id="settings-trail-label">2.0s</span></label>

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -19,7 +19,7 @@ import { onScoreLoaded, onScoreCleared, getSession } from '../../services/score-
 import { onPlaybackSyncEvent } from '../../services/playback-sync';
 import { showErrorBanner } from '../../services/backend';
 import { getFrameXPosition } from '../../services/cursor-projection';
-import { MIN_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from '../../pitch/overlay';
+import { DEFAULT_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from '../../pitch/overlay';
 import { PitchGraphCanvas } from '../../pitch/graph';
 import { expectedNoteAtBeat } from '../../pitch/accuracy';
 import { syntheticPitchFrameAt } from '../../pitch/synthetic';
@@ -59,7 +59,7 @@ let playbackSyncUnsubscribe: (() => void) | null = null;
 let syncOffsetWarningShown = false;
 
 const overlaySettings: OverlaySettings = {
-  confidenceThreshold: MIN_CONFIDENCE_THRESHOLD,
+  confidenceThreshold: DEFAULT_CONFIDENCE_THRESHOLD,
   trailMs: 2000,
 };
 

--- a/frontend/src/pitch/overlay.test.ts
+++ b/frontend/src/pitch/overlay.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  DEFAULT_CONFIDENCE_THRESHOLD,
   MAX_CONFIDENCE_THRESHOLD,
   MAX_TRAIL_MS,
   MIN_CONFIDENCE_THRESHOLD,
@@ -13,7 +14,7 @@ describe('normalizeOverlaySettings', () => {
       confidenceThreshold: 0.1,
       trailMs: 50,
     })).toEqual({
-      confidenceThreshold: MIN_CONFIDENCE_THRESHOLD,
+      confidenceThreshold: 0.1,
       trailMs: MIN_TRAIL_MS,
     });
 
@@ -31,7 +32,7 @@ describe('normalizeOverlaySettings', () => {
       confidenceThreshold: Number.NaN,
       trailMs: Number.POSITIVE_INFINITY,
     })).toEqual({
-      confidenceThreshold: MIN_CONFIDENCE_THRESHOLD,
+      confidenceThreshold: DEFAULT_CONFIDENCE_THRESHOLD,
       trailMs: 2000,
     });
   });

--- a/frontend/src/pitch/overlay.ts
+++ b/frontend/src/pitch/overlay.ts
@@ -3,8 +3,9 @@ import { elapsedToBeat } from '../score/timing';
 import { classifyPitchColor, expectedNoteAtBeat, MIN_CONFIDENCE_FOR_DOT, type DotColor } from './accuracy';
 import { createPitchInterpreter, noteKey, type PitchInterpreter } from './interpretation';
 
-export const MIN_CONFIDENCE_THRESHOLD = MIN_CONFIDENCE_FOR_DOT;
+export const MIN_CONFIDENCE_THRESHOLD = 0;
 export const MAX_CONFIDENCE_THRESHOLD = 0.95;
+export const DEFAULT_CONFIDENCE_THRESHOLD = MIN_CONFIDENCE_FOR_DOT;
 export const MIN_TRAIL_MS = 500;
 export const MAX_TRAIL_MS = 5000;
 
@@ -22,7 +23,7 @@ export interface OverlaySettings {
 export function normalizeOverlaySettings(settings: OverlaySettings): OverlaySettings {
   const threshold = Number.isFinite(settings.confidenceThreshold)
     ? settings.confidenceThreshold
-    : MIN_CONFIDENCE_THRESHOLD;
+    : DEFAULT_CONFIDENCE_THRESHOLD;
   const trailMs = Number.isFinite(settings.trailMs)
     ? settings.trailMs
     : 2000;
@@ -65,7 +66,7 @@ export class PitchOverlay {
     this.midiMin = 48;
     this.midiMax = 84;
     this.setPart(part);
-    this.settings = normalizeOverlaySettings(settings ?? { confidenceThreshold: MIN_CONFIDENCE_THRESHOLD, trailMs: 2000 });
+    this.settings = normalizeOverlaySettings(settings ?? { confidenceThreshold: DEFAULT_CONFIDENCE_THRESHOLD, trailMs: 2000 });
     this.interpreter = createPitchInterpreter();
 
     this.canvas = document.createElement('canvas');


### PR DESCRIPTION
### Motivation
- The settings UI prevented lowering the confidence gate because the slider `min` was `0.6` while the default is also `0.6`, so users could not select lower confidence values needed in noisy/quiet scenarios.

### Description
- Changed the settings slider in `frontend/index.html` to `min="0"` while keeping `value="0.6"` so the UI can emit values below `0.6`.
- Split overlay constants in `frontend/src/pitch/overlay.ts` into `MIN_CONFIDENCE_THRESHOLD = 0` and `DEFAULT_CONFIDENCE_THRESHOLD = MIN_CONFIDENCE_FOR_DOT` and updated normalization to use the distinct default and minimum.
- Updated initialization in `frontend/src/features/pitch-overlay/index.ts` to use `DEFAULT_CONFIDENCE_THRESHOLD` so the runtime default remains `0.6`.
- Adjusted `frontend/src/pitch/overlay.test.ts` expectations to accept values like `0.1` (no longer clamped to `0.6`) and to still fall back to `DEFAULT_CONFIDENCE_THRESHOLD` for non-finite inputs.

### Testing
- Ran `npm test -- src/pitch/overlay.test.ts` and the overlay unit tests passed (2 tests passed).
- Ran full `npm test`; overlay-related changes are present but the repository has an unrelated existing failure in `src/pitch/timeline-sync.test.ts` which caused the full test run to report failures (this unrelated test failure pre-existed in the environment).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c842c2a8832796bfa3cd7b7c21e0)