### PR TITLE
fix: preserve binary MXL uploads in /score

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,6 @@ Day 6: Playback state machine + real WebSocket pitch stream.
 """
 
 import asyncio
-import tempfile
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, HTTPException
@@ -13,6 +12,7 @@ from fastapi.responses import JSONResponse
 import uvicorn
 
 from .score.parser import parse_musicxml
+from .score.upload import persist_upload_to_temp
 from .audio.capture import list_input_devices, default_input_device_id
 from .audio.pipeline import PlaybackPipeline, _CLIENT_QUEUE_MAXSIZE
 
@@ -224,10 +224,7 @@ async def load_score(file: UploadFile = File(...)) -> JSONResponse:
             detail=f"Unsupported file type '{suffix}'. Upload a .xml or .mxl MusicXML file.",
         )
 
-    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
-        tmp_path = Path(tmp.name)
-        content = await file.read()
-        tmp.write(content)
+    tmp_path = await persist_upload_to_temp(file, suffix)
 
     try:
         score_model = parse_musicxml(tmp_path)

--- a/backend/score/upload.py
+++ b/backend/score/upload.py
@@ -1,0 +1,22 @@
+"""Helpers for persisting uploaded score files safely."""
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from pathlib import Path
+
+from fastapi import UploadFile
+
+
+async def persist_upload_to_temp(file: UploadFile, suffix: str) -> Path:
+    """Write an UploadFile to a temp path, preserving exact binary bytes."""
+    await file.seek(0)
+
+    with tempfile.NamedTemporaryFile(suffix=suffix, delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+        shutil.copyfileobj(file.file, tmp)
+        tmp.flush()
+
+    return tmp_path
+

--- a/backend/tests/test_upload.py
+++ b/backend/tests/test_upload.py
@@ -1,0 +1,33 @@
+"""Tests for uploaded score temp-file persistence."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+from fastapi import UploadFile
+
+from backend.score.upload import persist_upload_to_temp
+
+
+@pytest.mark.asyncio
+async def test_persist_upload_to_temp_preserves_binary_mxl_bytes(tmp_path):
+    """MXL uploads must be written losslessly for music21 ZIP autodetection."""
+    data = io.BytesIO()
+    with zipfile.ZipFile(data, mode="w", compression=zipfile.ZIP_DEFLATED) as zf:
+        zf.writestr("META-INF/container.xml", "<container/>")
+        zf.writestr("score.xml", "<score-partwise version='3.1'/>")
+
+    payload = data.getvalue()
+    upload = UploadFile(filename="sample.mxl", file=io.BytesIO(payload))
+
+    saved_path = await persist_upload_to_temp(upload, ".mxl")
+    try:
+        assert saved_path.suffix == ".mxl"
+        saved = saved_path.read_bytes()
+        assert saved == payload
+        with zipfile.ZipFile(io.BytesIO(saved)) as zf:
+            assert "score.xml" in zf.namelist()
+    finally:
+        saved_path.unlink(missing_ok=True)


### PR DESCRIPTION
### Motivation
- Uploading `.mxl` (ZIP-based MusicXML) files was causing `music21` to fail with HTTP 422 because the backend temp-file write path could strip ZIP headers or lose the `.mxl` suffix used for autodetection. 

### Description
- Add `backend/score/upload.py` with `persist_upload_to_temp()` that rewinds the `UploadFile` stream and uses `shutil.copyfileobj` to write the exact binary bytes to a temp file while preserving the original suffix. 
- Update the `/score` upload handler in `backend/main.py` to call `persist_upload_to_temp()` instead of manually reading/writing bytes inline. 
- Add `backend/tests/test_upload.py`, a regression test that builds an in-memory ZIP `.mxl`, persists it via the helper, asserts byte-for-byte equality and verifies the saved file is a valid ZIP containing the expected XML.

### Testing
- Ran linter: `uv run ruff check backend/ --fix` and it passed with no remaining fixes. 
- Ran unit tests: `uv run pytest backend/tests/test_upload.py backend/tests/test_score.py -q` and all tests passed (39 passed, 1 warning).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c82d9aa48327998f708a396e3093)