### PR TITLE
Fix misleading MusicXML error banner for soundfont/setup failures

### DIFF
--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -10,7 +10,7 @@
  * After a score loads it publishes a ScoreSession via setSession().
  * Before loading it calls clearSession() so other features can tear down.
  */
-import { ScoreRenderer } from '../../score/renderer';
+import { ScoreRenderer, type ScoreModel } from '../../score/renderer';
 import { ScoreCursor } from '../../score/cursor';
 import { PlaybackEngine } from '../../playback/engine';
 import {
@@ -92,9 +92,20 @@ function mount(slot: HTMLElement): void {
     });
 
     const renderer = new ScoreRenderer(scoreContainerEl);
-    try {
-      const model = await renderer.load(file);
+    let model: ScoreModel;
 
+    try {
+      model = await renderer.load(file);
+    } catch (err) {
+      showErrorBanner('Could not load this MusicXML file. Try exporting again from notation software.');
+      setStatus(String(err), 'error');
+      console.error('Score parse/render failed:', err);
+      dropZoneEl.classList.remove('hidden');
+      hideLoading();
+      return;
+    }
+
+    try {
       // Populate part selector
       const visibleParts = getVisiblePartOptions(model.parts, showAccompEl.checked);
       partSelectEl.innerHTML = visibleParts
@@ -132,9 +143,9 @@ function mount(slot: HTMLElement): void {
       setTransportEnabled(true);
       setStatus('score loaded', 'ok');
     } catch (err) {
-      showErrorBanner('Could not load this MusicXML file. Try exporting again from notation software.');
+      showErrorBanner('Score loaded, but playback setup failed. Check audio/soundfont settings and try again.');
       setStatus(String(err), 'error');
-      console.error('Score load failed:', err);
+      console.error('Post-parse score setup failed:', err);
       dropZoneEl.classList.remove('hidden');
     } finally {
       hideLoading();


### PR DESCRIPTION
### Motivation
- The score-loader previously caught both parse/render errors and post-parse setup errors (session/audio/soundfont/init) in a single handler and showed a MusicXML-specific error banner even when the MusicXML parsed and rendered correctly (issue #128). 

### Description
- Split the score loading flow in `frontend/src/features/score-loader/index.ts` into two error boundaries so `renderer.load(file)` parse/render failures are handled separately from post-parse playback/session setup errors. 
- Preserve the existing MusicXML-specific banner for true parse/render failures and show a new, specific banner `Score loaded, but playback setup failed. Check audio/soundfont settings and try again.` for playback/soundfont/session setup issues. 
- Added an explicit `ScoreModel` type import from `frontend/src/score/renderer.ts` and typed the `model` variable to satisfy TypeScript and clarify the control flow. 
- Improved console logging messages to clearly distinguish `Score parse/render failed` from `Post-parse score setup failed` for easier debugging.

### Testing
- Ran the soundfont unit tests with `npm --prefix frontend run test -- src/playback/soundfont.test.ts` which passed (`2 tests` passed). 
- Attempted build with `npm --prefix frontend run build` which failed due to an existing unrelated TypeScript error (`unused import` in `src/pitch/overlay.ts`), not caused by this change. 
- Ran `npm --prefix frontend run test -- score-loader` which exited non-zero because no matching test files exist for the feature (no tests to run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c81a7b3483279466dd9b60b182ab)