### PR TITLE
Fix soundfont JSON extraction for large CDN payloads

### DIFF
--- a/frontend/src/playback/soundfont.test.ts
+++ b/frontend/src/playback/soundfont.test.ts
@@ -13,6 +13,17 @@ describe('SoundfontLoader.parseNoteMap', () => {
     });
   });
 
+
+
+  it('parses when sample payload contains braces before object end', () => {
+    const js = 'MIDI.Soundfont.acoustic_grand_piano = {"A0":"data:audio/mp3;base64,QQ==","A1":"value}still-string"};';
+
+    expect(SoundfontLoader.parseNoteMap(js)).toEqual({
+      A0: 'data:audio/mp3;base64,QQ==',
+      A1: 'value}still-string',
+    });
+  });
+
   it('throws when no soundfont assignment is present', () => {
     expect(() => SoundfontLoader.parseNoteMap('<!doctype html>403 Forbidden')).toThrow(
       'Could not parse soundfont JS: no JSON object found',

--- a/frontend/src/playback/soundfont.ts
+++ b/frontend/src/playback/soundfont.ts
@@ -18,8 +18,7 @@
 const SOUNDFONT_URL =
   'https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/acoustic_grand_piano-mp3.js';
 
-const SOUNDFONT_ASSIGNMENT_RE =
-  /MIDI\.Soundfont\.[A-Za-z0-9_]+\s*=\s*(\{[\s\S]*?\})\s*;?/;
+const SOUNDFONT_ASSIGNMENT_RE = /MIDI\.Soundfont\.[A-Za-z0-9_]+\s*=/;
 
 // Flat-notation names matching the gleitz soundfont key names exactly.
 // MIDI 0 = C-1, MIDI 60 = C4, MIDI 69 = A4.
@@ -138,8 +137,50 @@ export class SoundfontLoader {
   static midiToNoteName = midiToNoteName;
   static noteNameToMidi = noteNameToMidi;
   static parseNoteMap(js: string): Record<string, string> {
-    const match = js.match(SOUNDFONT_ASSIGNMENT_RE);
-    if (!match) throw new Error('Could not parse soundfont JS: no JSON object found');
-    return JSON.parse(match[1]) as Record<string, string>;
+    const assignment = js.match(SOUNDFONT_ASSIGNMENT_RE);
+    if (!assignment || assignment.index === undefined) {
+      throw new Error('Could not parse soundfont JS: no JSON object found');
+    }
+
+    const objStart = js.indexOf('{', assignment.index + assignment[0].length);
+    if (objStart < 0) throw new Error('Could not parse soundfont JS: no JSON object found');
+
+    let depth = 0;
+    let inString = false;
+    let escaping = false;
+
+    for (let i = objStart; i < js.length; i++) {
+      const ch = js[i];
+
+      if (inString) {
+        if (escaping) {
+          escaping = false;
+          continue;
+        }
+        if (ch === '\\') {
+          escaping = true;
+          continue;
+        }
+        if (ch === '"') inString = false;
+        continue;
+      }
+
+      if (ch === '"') {
+        inString = true;
+        continue;
+      }
+      if (ch === '{') {
+        depth += 1;
+        continue;
+      }
+      if (ch === '}') {
+        depth -= 1;
+        if (depth === 0) {
+          return JSON.parse(js.slice(objStart, i + 1)) as Record<string, string>;
+        }
+      }
+    }
+
+    throw new Error('Could not parse soundfont JS: no JSON object found');
   }
 }


### PR DESCRIPTION
### Motivation
- The previous lazy-regex extraction in `SoundfontLoader.parseNoteMap` could stop at the first `}` and truncate the CDN-provided JS payload, causing `JSON.parse` to fail and breaking audio playback.
- The failure was silent and affected all playback because the soundfont map could not be constructed.
- A robust scanner is needed to find the full top-level `{…}` even when sample strings contain `}` or escaped characters.

### Description
- Replace the fragile capture-regex with a simpler assignment match and a brace-aware scanner that finds the full top-level object after `MIDI.Soundfont.* =` in `frontend/src/playback/soundfont.ts`.
- The scanner correctly handles quoted strings and escaped characters while tracking brace depth to locate the matching closing `}` before calling `JSON.parse`.
- Preserve existing error messages when no valid object can be found and add a regression test `frontend/src/playback/soundfont.test.ts` that includes a `}` inside a sample string to prevent regressions.

### Testing
- Ran the focused unit tests with `cd frontend && npm test -- soundfont.test.ts` and the suite passed.
- All soundfont parsing tests passed (`3 tests` passed).
- The new regression test verifies that braces inside sample payload strings no longer cause truncation or `JSON.parse` failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c8029de483279eebfcaa9ca731a0)