### PR TITLE
Fix infinite recursion on score load by separating part-change notifications

### DIFF
--- a/frontend/src/features/part-selector/index.ts
+++ b/frontend/src/features/part-selector/index.ts
@@ -60,7 +60,7 @@ function mount(_slot: HTMLElement): void {
     partSelectEl.value = selectedPart;
     partSelectEl.disabled = visibleParts.length <= 1;
     scheduleSelectedPart(selectedPart);
-    updateSelectedPart(selectedPart);
+    if (session.selectedPart !== selectedPart) updateSelectedPart(selectedPart);
   }
 
   onScoreCleared(() => { partSelectEl.innerHTML = ''; });

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -15,7 +15,7 @@
  * Imports getFrameXPosition from services/cursor-projection (not from the
  * playback feature) to preserve feature isolation.
  */
-import { onScoreLoaded, onScoreCleared, getSession } from '../../services/score-session';
+import { onScoreLoaded, onScoreCleared, onPartChanged, getSession } from '../../services/score-session';
 import { onPlaybackSyncEvent } from '../../services/playback-sync';
 import { showErrorBanner } from '../../services/backend';
 import { getFrameXPosition } from '../../services/cursor-projection';
@@ -361,6 +361,21 @@ function mount(_slot: HTMLElement): void {
     clearPhraseSummaryPanel();
     updatePitchReadout();
     connectPitchSocket();
+  });
+
+  onPartChanged((session) => {
+    if (!pitchOverlay) return;
+    pitchOverlay.destroy();
+    pitchOverlay = new PitchOverlay(
+      scoreContainerEl, session.model, session.selectedPart, overlaySettings);
+    activePartNotes = session.model.notes.filter((n) => n.part === session.selectedPart);
+    phraseSummaryTracker = new PhraseSummaryTracker(activePartNotes, session.model.tempo_marks);
+    pitchGraph?.clear();
+    timelineSync.reset();
+    lastPitchFrame = null;
+    pitchGraphNowSec = 0;
+    clearPhraseSummaryPanel();
+    updatePitchReadout();
   });
 
   btnStop.addEventListener('click', () => {

--- a/frontend/src/services/score-session.test.ts
+++ b/frontend/src/services/score-session.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function buildSession(selectedPart: string) {
+  return {
+    model: {
+      title: 'Test',
+      parts: ['Soprano', 'Alto'],
+      notes: [],
+      tempo_marks: [],
+      time_signatures: [],
+      total_beats: 0,
+    },
+    renderer: {} as never,
+    cursor: {} as never,
+    engine: {} as never,
+    selectedPart,
+  };
+}
+
+describe('score-session store', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('notifies score-loaded listeners only when session loads', async () => {
+    const store = await import('./score-session');
+    const onLoaded = vi.fn();
+    const onPartChanged = vi.fn();
+
+    store.onScoreLoaded(onLoaded);
+    store.onPartChanged(onPartChanged);
+
+    const session = buildSession('Soprano');
+    store.setSession(session);
+    store.updateSelectedPart('Alto');
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(onLoaded).toHaveBeenCalledWith(session);
+
+    expect(onPartChanged).toHaveBeenCalledTimes(1);
+    expect(onPartChanged).toHaveBeenNthCalledWith(1, {
+      ...session,
+      selectedPart: 'Alto',
+    });
+  });
+
+  it('does not notify part-changed listeners when selected part is unchanged', async () => {
+    const store = await import('./score-session');
+    const onPartChanged = vi.fn();
+
+    store.onPartChanged(onPartChanged);
+
+    const session = buildSession('Soprano');
+    store.setSession(session);
+    store.updateSelectedPart('Soprano');
+
+    expect(onPartChanged).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/src/services/score-session.ts
+++ b/frontend/src/services/score-session.ts
@@ -30,6 +30,7 @@ type SessionCallback = (session: ScoreSession) => void;
 type ClearCallback = () => void;
 
 const loadedCallbacks: SessionCallback[] = [];
+const partChangedCallbacks: SessionCallback[] = [];
 const clearCallbacks: ClearCallback[] = [];
 
 let current: ScoreSession | null = null;
@@ -67,18 +68,28 @@ export function onScoreLoaded(cb: SessionCallback): void {
   if (current) cb(current);
 }
 
+/**
+ * Register a callback fired whenever selectedPart changes on the current
+ * session. If a session already exists at registration time the callback
+ * fires immediately with the current selectedPart.
+ */
+export function onPartChanged(cb: SessionCallback): void {
+  partChangedCallbacks.push(cb);
+  if (current) cb(current);
+}
+
 /** Register a callback fired just before each session tear-down. */
 export function onScoreCleared(cb: ClearCallback): void {
   clearCallbacks.push(cb);
 }
 
 /**
- * Update selectedPart on the current session snapshot and re-notify all
- * onScoreLoaded subscribers. Called by the part-selector feature so
- * pitch-overlay can react without a direct feature-to-feature coupling.
+ * Update selectedPart on the current session snapshot and notify only
+ * onPartChanged subscribers.
  */
 export function updateSelectedPart(part: string): void {
   if (!current) return;
+  if (current.selectedPart === part) return;
   current = { ...current, selectedPart: part };
-  for (const cb of loadedCallbacks) cb(current);
+  for (const cb of partChangedCallbacks) cb(current);
 }


### PR DESCRIPTION
### Motivation
- Loading a score caused a stack overflow due to a notification cycle: `setSession()` → `onScoreLoaded` subscribers → `refreshPartSelector()` → `updateSelectedPart()` → re-notify `onScoreLoaded` → ….
- The intent is to allow features to react to a session load and to part selection changes independently without forming a recursive feedback loop.

### Description
- Introduced a new `onPartChanged` subscription list and `onPartChanged()` API in `frontend/src/services/score-session.ts` for part-change notifications.
- Changed `updateSelectedPart()` to no-op when the selected part is unchanged and to notify only `onPartChanged` listeners instead of re-firing `onScoreLoaded` listeners.
- Updated `part-selector` (`frontend/src/features/part-selector/index.ts`) to call `updateSelectedPart()` only when the selection actually changes during refresh.
- Updated `pitch-overlay` (`frontend/src/features/pitch-overlay/index.ts`) to subscribe to `onPartChanged()` and rebuild overlay/tracker state on part changes, and added focused unit tests for the session store behavior (`frontend/src/services/score-session.test.ts`).

### Testing
- Ran targeted unit tests with `npx vitest run src/services/score-session.test.ts src/pitch/overlay.test.ts`, and they passed ✅.
- Ran the full test suite with `npm test`; this surfaced a pre-existing unrelated failure in `src/pitch/timeline-sync.test.ts` (so overall `npm test` reported failures ⚠️).
- Attempted `npm run build`, which failed due to an unrelated TypeScript lint/error (`TS6133` unused `classifyPitchColor` in `src/pitch/overlay.ts`), so a full production build was not completed ⚠️.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5c7d846708327af735465f9e5a008)