### PR TITLE
Add dev-only musescore serving and one-click test score loading

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -460,6 +460,7 @@
       </div>
 
       <button id="btn-browse"   class="transport-btn">Browse…</button>
+      <button id="btn-load-test-score" class="transport-btn" style="display:none;">Load test score</button>
       <button id="btn-diagnostics" class="transport-btn">Pitch diagnostics</button>
       <button id="btn-settings" class="transport-btn">⚙ Settings</button>
 

--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -39,6 +39,7 @@ function mount(slot: HTMLElement): void {
   const tempoSliderEl     = document.getElementById('tempo-slider')       as HTMLInputElement;
   const transposeSelectEl = document.getElementById('transpose-select')   as HTMLSelectElement;
   const headphoneWarning  = document.getElementById('headphone-warning')  as HTMLDivElement;
+  const btnLoadTestScore  = document.getElementById('btn-load-test-score') as HTMLButtonElement | null;
 
   // ── Loading overlay ─────────────────────────────────────────────────────────
   const dropZoneIdleMarkup = dropZoneEl.innerHTML;
@@ -80,6 +81,23 @@ function mount(slot: HTMLElement): void {
   }
 
   // ── Score loading ─────────────────────────────────────────────────────────
+
+  async function loadDevTestScore(filename: string): Promise<void> {
+    try {
+      setStatus(`Loading test score ${filename}…`, 'loading');
+      const response = await fetch(`/musescore/${filename}`);
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+
+      const blob = await response.blob();
+      const file = new File([blob], filename, { type: blob.type || 'application/vnd.recordare.musicxml+xml' });
+      await loadScore(file);
+    } catch (err) {
+      showErrorBanner(`Could not load test score ${filename}.`);
+      setStatus(`test score load failed: ${String(err)}`, 'error');
+      console.error('Dev test score load failed:', err);
+    }
+  }
+
   async function loadScore(file: File): Promise<void> {
     clearErrorBanner();
     showLoading(`Loading ${file.name}…`);
@@ -214,6 +232,21 @@ function mount(slot: HTMLElement): void {
 
   const btnBrowse = document.getElementById('btn-browse') as HTMLButtonElement;
   btnBrowse.addEventListener('click', () => fileInputEl.click());
+
+  if (btnLoadTestScore) {
+    const devScoreFilename = 'homeward_bound.mxl';
+    void fetch(`/musescore/${devScoreFilename}`, { method: 'HEAD' })
+      .then((response) => {
+        if (!response.ok) return;
+        btnLoadTestScore.style.display = '';
+        btnLoadTestScore.addEventListener('click', () => {
+          void loadDevTestScore(devScoreFilename);
+        });
+      })
+      .catch(() => {
+        // Test score endpoint unavailable (e.g. production build).
+      });
+  }
 
   fileInputEl.addEventListener('change', () => {
     const file = fileInputEl.files?.[0];

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,6 +1,39 @@
+import { createReadStream, existsSync, statSync } from 'node:fs'
+import { resolve, sep } from 'node:path'
+import type { Plugin } from 'vite'
 import { defineConfig } from 'vite'
 
+const museScoreRoot = resolve(__dirname, '../musescore')
+
+function devMusescorePlugin(): Plugin {
+  return {
+    name: 'dev-musescore-static',
+    apply: 'serve',
+    configureServer(server) {
+      server.middlewares.use('/musescore', (req, res, next) => {
+        const rawPath = req.url?.split('?')[0] ?? '/'
+        const relativePath = rawPath.startsWith('/') ? rawPath.slice(1) : rawPath
+        const fullPath = resolve(museScoreRoot, relativePath)
+
+        if (!fullPath.startsWith(`${museScoreRoot}${sep}`)) {
+          res.statusCode = 403
+          res.end('Forbidden')
+          return
+        }
+
+        if (!existsSync(fullPath) || !statSync(fullPath).isFile()) {
+          return next()
+        }
+
+        res.setHeader('Content-Type', 'application/vnd.recordare.musicxml+xml')
+        createReadStream(fullPath).pipe(res)
+      })
+    },
+  }
+}
+
 export default defineConfig({
+  plugins: [devMusescorePlugin()],
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
### Motivation
- QA and demos require repeatedly dragging MusicXML files into the browser because the repo-root `musescore/` directory is not served by the Vite dev server. 
- The goal is to make at least one test score loadable in development via a browser URL or single button click without adding test files to the production build.

### Description
- Add a Vite dev-server plugin in `frontend/vite.config.ts` that serves files from the repo-root `musescore/` directory under the `/musescore/*` path and only applies during `vite` serve. 
- Harden the middleware with a path-traversal guard and a passthrough to `next()` for missing files, and set `Content-Type: application/vnd.recordare.musicxml+xml` for served files. 
- Add a hidden `Load test score` toolbar button to `frontend/index.html` that is revealed at runtime when `/musescore/homeward_bound.mxl` is reachable (HEAD check). 
- Wire the button in `frontend/src/features/score-loader/index.ts` to fetch the test score and pass it into the existing `loadScore(File)` flow for identical parsing and playback handling.

### Testing
- Dev server verified by running `npm --prefix frontend run dev -- --host 0.0.0.0 --port 5173` and confirming `curl -I http://127.0.0.1:5173/musescore/homeward_bound.mxl` returned `HTTP/1.1 200 OK` with MusicXML content-type. 
- Attempted UI validation via Playwright screenshot, but Chromium crashed in this environment (SIGSEGV), so no screenshot artifact was produced. 
- Ran frontend unit tests with `npm --prefix frontend test`, which exposed pre-existing unrelated failures (4 failing tests across `src/services/progress-history.test.ts` and `src/pitch/timeline-sync.test.ts`), not introduced by this change. 
- Running `npm --prefix frontend run build` failed due to pre-existing TypeScript/noUnusedLocals issues unrelated to the dev-only serving feature.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dc41b9b88327b88e8af43f77065d)

Closes #134 