### PR TITLE
Unify in-tune thresholds across graph trace, overlay dot, and legends

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -505,7 +505,7 @@
       <section id="pitch-graph-panel" aria-label="Pitch graph panel">
         <div id="pitch-graph-header">
           <span>Pitch graph (C2–C6, 10s window)</span>
-          <span>Blue: expected pitch &middot; Green: &plusmn;25 cents &middot; Red: out of tune &middot; Grey: no target</span>
+          <span>Blue band: expected pitch &plusmn;50 cents &middot; Green trace/dot: within &plusmn;50 cents &middot; Red: out of tune &middot; Grey: no target</span>
         </div>
         <div id="pitch-graph-canvas"></div>
       </section>

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -21,7 +21,7 @@ import { showErrorBanner } from '../../services/backend';
 import { getFrameXPosition } from '../../services/cursor-projection';
 import { DEFAULT_CONFIDENCE_THRESHOLD, PitchOverlay, type OverlaySettings } from '../../pitch/overlay';
 import { PitchGraphCanvas } from '../../pitch/graph';
-import { expectedNoteAtBeat } from '../../pitch/accuracy';
+import { expectedNoteAtBeat, GREEN_CENTS_THRESHOLD, AMBER_CENTS_THRESHOLD } from '../../pitch/accuracy';
 import { syntheticPitchFrameAt } from '../../pitch/synthetic';
 import { PitchTimelineSync } from '../../pitch/timeline-sync';
 import { parsePitchSocketMessage, reconnectDelayMs } from '../../pitch/socket';
@@ -193,7 +193,7 @@ function renderPhraseSummary(summary: PhraseSummary): void {
     <div class="phrase-summary-card">
       <div class="phrase-summary-title">Phrase ${summary.phraseId} · ${summary.withinTolerancePct.toFixed(0)}% in tolerance</div>
       <div class="phrase-summary-notes">${notesHtml}</div>
-      <div class="phrase-summary-legend">🟢 ≤50c · 🟡 51–100c · 🔴 &gt;100c</div>
+      <div class="phrase-summary-legend">🟢 ≤${GREEN_CENTS_THRESHOLD}c · 🟡 ${GREEN_CENTS_THRESHOLD + 1}–${AMBER_CENTS_THRESHOLD}c · 🔴 &gt;${AMBER_CENTS_THRESHOLD}c</div>
     </div>
   `;
 }

--- a/frontend/src/pitch/graph-colors.ts
+++ b/frontend/src/pitch/graph-colors.ts
@@ -1,6 +1,12 @@
+import { GREEN_CENTS_THRESHOLD } from './accuracy';
+
 export type GraphTraceColor = 'green' | 'red' | 'grey';
 
-export const GRAPH_IN_TUNE_CENTS = 25;
+/**
+ * Graph trace uses the same in-tune threshold as the score dot/phrase summary
+ * so all pitch feedback surfaces remain visually consistent for singers.
+ */
+export const GRAPH_IN_TUNE_CENTS = GREEN_CENTS_THRESHOLD;
 
 export function centsError(sungMidi: number, expectedMidi: number): number {
   return (sungMidi - expectedMidi) * 100;

--- a/frontend/src/pitch/graph.test.ts
+++ b/frontend/src/pitch/graph.test.ts
@@ -38,11 +38,11 @@ describe('graph color classification', () => {
     expect(classifyGraphTraceColor(60, null)).toBe('grey');
   });
 
-  it('respects ±25 cents in-tune threshold', () => {
-    expect(GRAPH_IN_TUNE_CENTS).toBe(25);
-    expect(classifyGraphTraceColor(60.25, 60)).toBe('green');
-    expect(classifyGraphTraceColor(60.26, 60)).toBe('red');
-    expect(Math.round(centsError(60.26, 60))).toBe(26);
+  it('respects ±50 cents in-tune threshold', () => {
+    expect(GRAPH_IN_TUNE_CENTS).toBe(50);
+    expect(classifyGraphTraceColor(60.5, 60)).toBe('green');
+    expect(classifyGraphTraceColor(60.51, 60)).toBe('red');
+    expect(Math.round(centsError(60.51, 60))).toBe(51);
   });
 });
 


### PR DESCRIPTION
### Motivation
- The pitch graph trace used a ±25-cent in-tune threshold while the score overlay dot and phrase summary used ±50 cents, producing inconsistent visual feedback to singers.
- The change aims to make pitch feedback surfaces visually consistent by sharing a single green/in‑tune threshold.

### Description
- Set `GRAPH_IN_TUNE_CENTS` to the shared `GREEN_CENTS_THRESHOLD` by importing it in `frontend/src/pitch/graph-colors.ts` and added a code comment documenting the rationale.
- Updated `frontend/src/pitch/graph.test.ts` to assert the ±50-cent behavior and boundary values for graph trace classification.
- Replaced hardcoded legend copy with dynamic values in `frontend/src/features/pitch-overlay/index.ts` so the phrase summary legend uses `GREEN_CENTS_THRESHOLD` and `AMBER_CENTS_THRESHOLD` constants.
- Updated the pitch graph header copy in `frontend/index.html` to reflect the actual thresholds (blue band ±50c, green trace/dot within ±50c).

### Testing
- Ran full frontend test suite with `npm test`, which failed due to pre-existing unrelated failures in `src/services/progress-history.test.ts` and `src/pitch/timeline-sync.test.ts` (those failures are not introduced by this change).
- Ran targeted unit tests with `npx vitest run src/pitch/graph.test.ts src/pitch/accuracy.test.ts src/pitch/phrase-summary.test.ts`, and those tests passed.

Closes #133 
------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dc28328883279f9e6f4184245ec2)