### PR TITLE
feat: graceful soundfont fallback with user notification

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -74,6 +74,36 @@
     }
     #error-banner.visible { display: block; }
 
+    /* ── Toast notifications ── */
+    #toast-stack {
+      position: fixed;
+      right: 20px;
+      bottom: 20px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      z-index: 60;
+      pointer-events: none;
+    }
+
+    .toast {
+      min-width: 280px;
+      max-width: 420px;
+      background: rgba(15, 52, 96, 0.95);
+      border: 1px solid #1a5276;
+      color: var(--color-text);
+      border-radius: 6px;
+      padding: 10px 12px;
+      font-size: 0.82rem;
+      box-shadow: 0 8px 16px rgba(0, 0, 0, 0.35);
+    }
+
+    .toast.warning {
+      border-color: var(--color-warning-border);
+      background: rgba(123, 63, 0, 0.95);
+      color: var(--color-warning-text);
+    }
+
     /* ── Headphone warning ── */
     #headphone-warning {
       background: var(--color-warning-bg);
@@ -398,6 +428,7 @@
   </header>
 
   <div id="error-banner" role="alert"></div>
+  <div id="toast-stack" aria-live="polite" aria-atomic="false"></div>
 
   <div id="headphone-warning" class="hidden">
     <span>🎧 Use headphones — speakers cause mic bleed and will break pitch detection.</span>

--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -18,9 +18,11 @@ import {
   getSoundfont,
   ensureSoundfontLoaded,
   getSoundfontLoadPromise,
+  getPlaybackTimbreMode,
 } from '../../services/audio-context';
 import { setSession, clearSession, getSession } from '../../services/score-session';
 import { setStatus, showErrorBanner, clearErrorBanner } from '../../services/backend';
+import { showToast } from '../../services/toast';
 import { getVisiblePartOptions } from '../../part-options';
 import { beatToMs, seekPlayback } from '../../transport/controls';
 import { beatFromClick, extractMeasureHitZones } from '../../score/click-seek';
@@ -95,7 +97,11 @@ function mount(slot: HTMLElement): void {
     // Kick off soundfont loading early (idempotent) so it overlaps with parse.
     ensureSoundfontLoaded((err) => {
       showErrorBanner('Soundfont failed to load; using synth fallback audio.');
-      setStatus('soundfont load failed — synth fallback active', 'error');
+      setStatus('soundfont unavailable — using synthesised tones', 'error');
+      showToast('Soundfont unavailable — using synthesised tones', {
+        variant: 'warning',
+        dedupeKey: 'soundfont-fallback',
+      });
       console.error('[Soundfont] load error:', err);
     });
 
@@ -149,7 +155,11 @@ function mount(slot: HTMLElement): void {
 
       setSession({ model, renderer, cursor, engine, selectedPart });
       setTransportEnabled(true);
-      setStatus('score loaded', 'ok');
+      if (getPlaybackTimbreMode() === 'synth-fallback') {
+        setStatus('score loaded — synth fallback active', 'error');
+      } else {
+        setStatus('score loaded', 'ok');
+      }
     } catch (err) {
       showErrorBanner('Score loaded, but playback setup failed. Check audio/soundfont settings and try again.');
       setStatus(String(err), 'error');

--- a/frontend/src/services/audio-context.test.ts
+++ b/frontend/src/services/audio-context.test.ts
@@ -1,0 +1,25 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('audio-context soundfont fallback mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+  });
+
+  it('switches to synth-fallback when soundfont load fails', async () => {
+    const audioContextStub = {} as AudioContext;
+    vi.stubGlobal('AudioContext', vi.fn(() => audioContextStub));
+
+    const { SoundfontLoader } = await import('../playback/soundfont');
+    vi.spyOn(SoundfontLoader.prototype, 'load').mockRejectedValueOnce(new Error('offline'));
+
+    const audioContext = await import('./audio-context');
+    const listener = vi.fn();
+    audioContext.onPlaybackTimbreModeChange(listener);
+
+    await audioContext.ensureSoundfontLoaded();
+
+    expect(audioContext.getPlaybackTimbreMode()).toBe('synth-fallback');
+    expect(listener).toHaveBeenCalledWith('loading');
+    expect(listener).toHaveBeenCalledWith('synth-fallback');
+  });
+});

--- a/frontend/src/services/audio-context.ts
+++ b/frontend/src/services/audio-context.ts
@@ -15,6 +15,18 @@ let ctx: AudioContext | null = null;
 let soundfont: SoundfontLoader | null = null;
 let loadPromise: Promise<void> | null = null;
 
+export type PlaybackTimbreMode = 'loading' | 'soundfont' | 'synth-fallback';
+
+let playbackTimbreMode: PlaybackTimbreMode = 'loading';
+const playbackTimbreModeListeners = new Set<(mode: PlaybackTimbreMode) => void>();
+
+function setPlaybackTimbreMode(mode: PlaybackTimbreMode): void {
+  playbackTimbreMode = mode;
+  for (const listener of playbackTimbreModeListeners) {
+    listener(mode);
+  }
+}
+
 /**
  * Return (creating if necessary) the shared AudioContext.
  * Also kicks off soundfont loading in the background on first call.
@@ -45,12 +57,18 @@ export function ensureSoundfontLoaded(
   onError?: (err: unknown) => void,
 ): Promise<void> {
   if (!loadPromise) {
+    setPlaybackTimbreMode('loading');
     const ac = getAudioContext();
     const sf = getSoundfont();
-    loadPromise = sf.load(ac).catch((err: unknown) => {
-      console.error('[Soundfont] load failed:', err);
-      onError?.(err);
-    });
+    loadPromise = sf.load(ac)
+      .then(() => {
+        setPlaybackTimbreMode('soundfont');
+      })
+      .catch((err: unknown) => {
+        setPlaybackTimbreMode('synth-fallback');
+        console.error('[Soundfont] load failed:', err);
+        onError?.(err);
+      });
   }
   return loadPromise;
 }
@@ -58,4 +76,17 @@ export function ensureSoundfontLoaded(
 /** Expose the raw load promise for features that need to await it. */
 export function getSoundfontLoadPromise(): Promise<void> | null {
   return loadPromise;
+}
+
+export function getPlaybackTimbreMode(): PlaybackTimbreMode {
+  return playbackTimbreMode;
+}
+
+export function onPlaybackTimbreModeChange(
+  listener: (mode: PlaybackTimbreMode) => void,
+): () => void {
+  playbackTimbreModeListeners.add(listener);
+  return () => {
+    playbackTimbreModeListeners.delete(listener);
+  };
 }

--- a/frontend/src/services/toast.ts
+++ b/frontend/src/services/toast.ts
@@ -1,0 +1,30 @@
+const activeToastKeys = new Set<string>();
+
+export type ToastVariant = 'info' | 'warning';
+
+export function showToast(
+  message: string,
+  options: {
+    variant?: ToastVariant;
+    durationMs?: number;
+    dedupeKey?: string;
+  } = {},
+): void {
+  const toastStackEl = document.getElementById('toast-stack') as HTMLDivElement | null;
+  if (!toastStackEl) return;
+
+  const { variant = 'info', durationMs = 4500, dedupeKey } = options;
+  if (dedupeKey && activeToastKeys.has(dedupeKey)) return;
+
+  if (dedupeKey) activeToastKeys.add(dedupeKey);
+
+  const el = document.createElement('div');
+  el.className = `toast ${variant === 'warning' ? 'warning' : ''}`.trim();
+  el.textContent = message;
+  toastStackEl.appendChild(el);
+
+  window.setTimeout(() => {
+    el.remove();
+    if (dedupeKey) activeToastKeys.delete(dedupeKey);
+  }, durationMs);
+}


### PR DESCRIPTION
### Motivation
- Ensure playback still works when the remote soundfont fails to load by falling back to synthesized oscillator tones and inform the user non-blockingly.

### Description
- Add a small toast system and global container (`#toast-stack`) to the frontend shell and expose `showToast()` in `frontend/src/services/toast.ts` and `frontend/index.html` to surface non-blocking messages.
- Track soundfont load state in `frontend/src/services/audio-context.ts` with a `PlaybackTimbreMode` (`loading | soundfont | synth-fallback`) and notify listeners via `onPlaybackTimbreModeChange()` so features can react to fallback state.
- Update score loading in `frontend/src/features/score-loader/index.ts` to call `ensureSoundfontLoaded()` early and show a warning toast `Soundfont unavailable — using synthesised tones` when loading fails while keeping playback setup alive and updating the status message accordingly.
- Add a focused test `frontend/src/services/audio-context.test.ts` that verifies the timbre mode transitions to `synth-fallback` when the `SoundfontLoader.load()` promise rejects.

### Testing
- Ran targeted unit tests: `npm test -- src/services/audio-context.test.ts src/playback/soundfont.test.ts`, both passed (✅).
- Ran the full frontend test suite (`npm test`), which surfaced pre-existing unrelated failures (6 failing tests) in other areas of the frontend test suite (✖️) and are outside the scope of this change.
- Attempted `npm run build`; build failed due to unrelated TypeScript issues in `src/pitch/overlay.ts` / tests (✖️), not introduced by these changes.
- Started the dev server and visually verified a toast can be rendered (dev server reachable and a screenshot captured) to confirm the UI plumbing for notifications (✅).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5dc1948a48327b15c095632168607)

Closes #132 