### PR TITLE
fix(score-loader): reset drop-zone to idle on MusicXML parse failure

### DIFF
--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -153,10 +153,8 @@ function mount(slot: HTMLElement): void {
     } catch (err) {
       showErrorBanner('Score loaded, but playback setup failed. Check audio/soundfont settings and try again.');
       setStatus(String(err), 'error');
-      console.error('Score load failed:', err);
-      resetDropZoneToIdle();
       console.error('Post-parse score setup failed:', err);
-      dropZoneEl.classList.remove('hidden');
+      resetDropZoneToIdle();
     } finally {
       hideLoading();
     }


### PR DESCRIPTION
### Motivation
- When a MusicXML parse/render fails the drop-zone retained stale "Loading…" or file-name text; the drop-zone should return to its idle state and only the error banner shown (issue #131).

### Description
- Replace the partial unhide in the parse/render error handler with a call to `resetDropZoneToIdle()` so the drop-zone DOM is restored to its initial markup and loading text is cleared (file: `frontend/src/features/score-loader/index.ts`).

### Testing
- Ran `npm test` in `frontend` which exercised the frontend unit suite but reported pre-existing unrelated test failures; the change does not affect the failing suites.
- Ran `npm run build` which reported pre-existing unrelated TypeScript errors outside this change; build failures are unrelated to the modification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5e7cb79b883278683d1296fda867b)

Closes #131 