### PR TITLE
feat: adaptive playback tempo control with live rescheduling

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -585,7 +585,7 @@
 
       <div class="tempo-group">
         <label for="tempo-slider">Tempo:</label>
-        <input id="tempo-slider" type="range" min="50" max="150" value="100" step="5" />
+        <input id="tempo-slider" type="range" min="50" max="125" value="100" step="5" />
         <span id="tempo-label">100%</span>
       </div>
 

--- a/frontend/src/features/part-selector/index.ts
+++ b/frontend/src/features/part-selector/index.ts
@@ -25,6 +25,37 @@ function mount(_slot: HTMLElement): void {
   const tempoSliderEl     = document.getElementById('tempo-slider')       as HTMLInputElement;
   const tempoLabelEl      = document.getElementById('tempo-label')        as HTMLSpanElement;
 
+
+  function clampTempoPercent(percent: number): number {
+    return Math.max(50, Math.min(125, percent));
+  }
+
+  function applyTempoUi(percent: number): void {
+    const clampedPercent = clampTempoPercent(percent);
+    tempoSliderEl.value = String(clampedPercent);
+    tempoLabelEl.textContent = `${clampedPercent}%`;
+  }
+
+  async function commitTempoChange(nextPercent: number): Promise<void> {
+    const session = getSession();
+    if (!session) return;
+    const { engine } = session;
+    const previousMultiplier = engine.tempoMultiplier;
+    const clampedPercent = clampTempoPercent(nextPercent);
+    const nextMultiplier = clampedPercent / 100;
+
+    applyTempoUi(clampedPercent);
+    engine.setTempoMultiplier(nextMultiplier);
+    try {
+      await setPlaybackTempo(nextMultiplier);
+    } catch (err) {
+      engine.setTempoMultiplier(previousMultiplier);
+      applyTempoUi(Math.round(previousMultiplier * 100));
+      setStatus(`tempo update failed: ${String(err)}`, 'error');
+      console.error('Tempo update failed:', err);
+    }
+  }
+
   function getTransposeSemitones(): number {
     const parsed = parseInt(transposeSelectEl.value, 10);
     return Number.isNaN(parsed) ? 0 : parsed;
@@ -79,26 +110,12 @@ function mount(_slot: HTMLElement): void {
   showAccompEl.addEventListener('change', () => { refreshPartSelector(); });
 
   // Tempo
-  tempoLabelEl.textContent = `${tempoSliderEl.value}%`;
+  applyTempoUi(parseInt(tempoSliderEl.value, 10));
   tempoSliderEl.addEventListener('input', () => {
-    tempoLabelEl.textContent = `${tempoSliderEl.value}%`;
+    applyTempoUi(parseInt(tempoSliderEl.value, 10));
   });
-  tempoSliderEl.addEventListener('change', async () => {
-    const session = getSession();
-    if (!session) return;
-    const { engine } = session;
-    const previousMultiplier = engine.tempoMultiplier;
-    const nextMultiplier = parseFloat(tempoSliderEl.value) / 100;
-    engine.setTempoMultiplier(nextMultiplier);
-    try {
-      await setPlaybackTempo(nextMultiplier);
-    } catch (err) {
-      engine.setTempoMultiplier(previousMultiplier);
-      tempoSliderEl.value = String(Math.round(previousMultiplier * 100));
-      tempoLabelEl.textContent = `${tempoSliderEl.value}%`;
-      setStatus(`tempo update failed: ${String(err)}`, 'error');
-      console.error('Tempo update failed:', err);
-    }
+  tempoSliderEl.addEventListener('change', () => {
+    void commitTempoChange(parseInt(tempoSliderEl.value, 10));
   });
 
   // Transpose

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -20,7 +20,7 @@ import { setStatus } from '../../services/backend';
 import { recordBeatSample, resetProjection, getCursorX } from '../../services/cursor-projection';
 import { finishPracticeSessionCapture, startPracticeSessionCapture } from '../../services/progress-history';
 import { emitPlaybackSyncEvent } from '../../services/playback-sync';
-import { beatToMs, postPlayback, startPlayback, seekPlayback } from '../../transport/controls';
+import { beatToMs, postPlayback, setPlaybackTempo, startPlayback, seekPlayback } from '../../transport/controls';
 import { sessionSummaryTracker, type SessionSummary } from '../../practice/session-summary';
 import { type Feature } from '../../feature-types';
 import { ensureAudioPreflightReady } from '../../services/audio-preflight';
@@ -80,6 +80,41 @@ async function seekByBeats(delta: number): Promise<void> {
   engine.seekToBeat(targetBeat);
   cursor.seekToBeat(targetBeat);
   if (engine.state !== 'playing') stopCursorRaf();
+}
+
+
+
+async function adjustTempoByStep(stepPercent: number): Promise<void> {
+  const session = getSession();
+  if (!session) return;
+
+  const tempoSliderEl = document.getElementById('tempo-slider') as HTMLInputElement | null;
+  const tempoLabelEl = document.getElementById('tempo-label') as HTMLSpanElement | null;
+  if (!tempoSliderEl || !tempoLabelEl) return;
+
+  const currentPercent = parseInt(tempoSliderEl.value, 10);
+  if (Number.isNaN(currentPercent)) return;
+
+  const nextPercent = Math.max(50, Math.min(125, currentPercent + stepPercent));
+  if (nextPercent === currentPercent) return;
+
+  const previousMultiplier = session.engine.tempoMultiplier;
+  const nextMultiplier = nextPercent / 100;
+
+  tempoSliderEl.value = String(nextPercent);
+  tempoLabelEl.textContent = `${nextPercent}%`;
+
+  session.engine.setTempoMultiplier(nextMultiplier);
+  try {
+    await setPlaybackTempo(nextMultiplier);
+  } catch (err) {
+    session.engine.setTempoMultiplier(previousMultiplier);
+    const previousPercent = Math.round(previousMultiplier * 100);
+    tempoSliderEl.value = String(previousPercent);
+    tempoLabelEl.textContent = `${previousPercent}%`;
+    setStatus(`tempo update failed: ${String(err)}`, 'error');
+    console.error('Tempo update failed:', err);
+  }
 }
 
 function getSelectedDeviceId(): number | null {
@@ -177,7 +212,7 @@ function mount(_slot: HTMLElement): void {
 
   function syncPauseButton(): void {
     const session = getSession();
-    if (!session || session.engine.state === 'stopped') {
+    if (!session || session.engine.state === 'idle') {
       btnPause.disabled = true;
       btnPause.innerHTML = '&#9646;&#9646; Pause';
       return;
@@ -375,7 +410,9 @@ function mount(_slot: HTMLElement): void {
     }
     if (e.code === 'KeyR') { e.preventDefault(); if (!btnRewind.disabled) btnRewind.click(); return; }
     if (e.code === 'ArrowLeft')  { e.preventDefault(); if (session.engine.state !== 'playing') void seekByBeats(-1); return; }
-    if (e.code === 'ArrowRight') { e.preventDefault(); if (session.engine.state !== 'playing') void seekByBeats(1); }
+    if (e.code === 'ArrowRight') { e.preventDefault(); if (session.engine.state !== 'playing') void seekByBeats(1); return; }
+    if (e.key === '[') { e.preventDefault(); void adjustTempoByStep(-5); return; }
+    if (e.key === ']') { e.preventDefault(); void adjustTempoByStep(5); }
   };
   window.addEventListener('keydown', onKeydown);
 

--- a/frontend/src/playback/engine.test.ts
+++ b/frontend/src/playback/engine.test.ts
@@ -6,7 +6,7 @@
  * tempo-multiplier cases without requiring an AudioContext mock.
  */
 import { describe, it, expect } from 'vitest';
-import { beatToSeconds, PlaybackEngine } from './engine';
+import { beatToSeconds, PlaybackEngine, scheduleNotes } from './engine';
 import { elapsedToBeat } from '../score/timing';
 
 const BPM120: import('../score/renderer').TempoMark[] = [{ beat: 0, bpm: 120 }];
@@ -76,6 +76,29 @@ describe('beatToSeconds / elapsedToBeat round-trip', () => {
       expect(recovered).toBeCloseTo(beat, 4);
     });
   }
+});
+
+
+
+describe('scheduleNotes', () => {
+  const notes: import('../score/renderer').NoteModel[] = [
+    { midi: 60, beat_start: 0, duration: 1, measure: 1, part: 'PART I', lyric: null },
+    { midi: 62, beat_start: 2, duration: 2, measure: 1, part: 'PART I', lyric: null },
+  ];
+
+  it('scales event start times at 75% tempo', () => {
+    const events = scheduleNotes(notes, BPM120, 0, 10, 0.75);
+    expect(events).toHaveLength(2);
+    expect(events[0].startAt).toBeCloseTo(10, 6);
+    expect(events[1].startAt).toBeCloseTo(11.333333, 5);
+  });
+
+  it('scales event start times at 50% tempo', () => {
+    const events = scheduleNotes(notes, BPM120, 0, 10, 0.5);
+    expect(events).toHaveLength(2);
+    expect(events[0].startAt).toBeCloseTo(10, 6);
+    expect(events[1].startAt).toBeCloseTo(12, 6);
+  });
 });
 
 describe('PlaybackEngine part selection', () => {

--- a/frontend/src/playback/engine.ts
+++ b/frontend/src/playback/engine.ts
@@ -64,6 +64,42 @@ export function beatToSeconds(
 
 export type PlaybackState = 'idle' | 'playing' | 'paused';
 
+export interface ScheduledNoteEvent {
+  note: NoteModel;
+  startAt: number;
+  durationS: number;
+}
+
+/**
+ * Build note schedule events for a given resume point and tempo multiplier.
+ *
+ * Returned startAt times are absolute AudioContext times in seconds.
+ */
+export function scheduleNotes(
+  notes: NoteModel[],
+  tempoMarks: TempoMark[],
+  fromBeat: number,
+  originTime: number,
+  tempoMultiplier: number,
+): ScheduledNoteEvent[] {
+  const originOffsetS = beatToSeconds(fromBeat, tempoMarks, tempoMultiplier);
+  return notes
+    .filter((note) => note.beat_start + note.duration > fromBeat)
+    .map((note) => {
+      const noteStartOffsetS =
+        beatToSeconds(note.beat_start, tempoMarks, tempoMultiplier) - originOffsetS;
+      const noteDurS =
+        beatToSeconds(note.beat_start + note.duration, tempoMarks, tempoMultiplier) -
+        beatToSeconds(note.beat_start, tempoMarks, tempoMultiplier) +
+        RELEASE_TAIL_S;
+      return {
+        note,
+        startAt: originTime + noteStartOffsetS,
+        durationS: noteDurS,
+      };
+    });
+}
+
 // Constants
 /** Seconds between play() call and first note — gives audio thread time to buffer. */
 const SCHEDULE_OFFSET_S = 0.1;
@@ -255,13 +291,14 @@ export class PlaybackEngine {
   }
 
   setTempoMultiplier(multiplier: number): void {
+    const clamped = Math.max(0.5, Math.min(1.25, multiplier));
     if (this._state !== 'playing') {
-      this._tempoMultiplier = multiplier;
+      this._tempoMultiplier = clamped;
       return;
     }
     const beat = this.currentBeat;
     this._stopSources();
-    this._tempoMultiplier = multiplier;
+    this._tempoMultiplier = clamped;
     this._startBeat = beat;
     this._startAudioTime = this.ctx.currentTime + RESCHEDULE_OFFSET_S;
     this._scheduleFrom(beat, this._startAudioTime);
@@ -293,29 +330,23 @@ export class PlaybackEngine {
    * behind ctx.currentTime) are also skipped to avoid scheduling overruns.
    */
   private _scheduleFrom(fromBeat: number, originTime: number): void {
-    const originOffsetS = beatToSeconds(fromBeat, this._tempoMarks, this._tempoMultiplier);
+    const events = scheduleNotes(
+      this._notes,
+      this._tempoMarks,
+      fromBeat,
+      originTime,
+      this._tempoMultiplier,
+    );
 
-    for (const note of this._notes) {
-      // Skip notes that ended before the resume point
-      if (note.beat_start + note.duration <= fromBeat) continue;
-
-      const noteStartOffsetS =
-        beatToSeconds(note.beat_start, this._tempoMarks, this._tempoMultiplier) - originOffsetS;
-      const startAt = originTime + noteStartOffsetS;
-
+    for (const event of events) {
       // Skip notes that are already too late to schedule
-      if (startAt < this.ctx.currentTime - LATE_TOLERANCE_S) continue;
+      if (event.startAt < this.ctx.currentTime - LATE_TOLERANCE_S) continue;
 
+      const note = event.note;
       const targetMidi = note.midi + this._transposeSemitones;
       const buf = this.sf.getBuffer(targetMidi);
-
-      // Duration in seconds + release tail for natural piano decay
-      const noteDurS =
-        beatToSeconds(note.beat_start + note.duration, this._tempoMarks, this._tempoMultiplier) -
-        beatToSeconds(note.beat_start, this._tempoMarks, this._tempoMultiplier) +
-        RELEASE_TAIL_S;
-
-      const safeStart = Math.max(startAt, this.ctx.currentTime + STOP_SAFETY_OFFSET_S);
+      const noteDurS = event.durationS;
+      const safeStart = Math.max(event.startAt, this.ctx.currentTime + STOP_SAFETY_OFFSET_S);
 
       if (buf) {
         const src = this.ctx.createBufferSource();


### PR DESCRIPTION
### Motivation
- Provide an in-session tempo control so singers can practice at a percentage of the written tempo (50%–125%) as requested in issue #103. 
- Ensure tempo changes take effect live during playback without cursor/audio drift by rescheduling pending audio events and keeping `engine.currentBeat` aligned with `AudioContext.currentTime`.
- Offer quick keyboard adjustments to match common notation tooling (`[` / `]`) and keep frontend/backend tempo state synchronized.

### Description
- Clamp the UI slider to the requested range by changing `tempo-slider` max to `125` in `frontend/index.html` and ensure UI label updates are clamped. (`#tempo-slider`, `#tempo-label`).
- Add an exported `scheduleNotes()` helper to `frontend/src/playback/engine.ts` to deterministically compute absolute `startAt` times and durations for notes given a tempo multiplier, and refactor `_scheduleFrom()` to use it.
- Enforce matching engine limits by clamping multipliers in `PlaybackEngine.setTempoMultiplier()` to `0.5..1.25` so internal scheduling aligns with the UI.
- Improve part-selector tempo handling with `applyTempoUi()` / `commitTempoChange()` helpers in `frontend/src/features/part-selector/index.ts` to clamp UI, update engine, and rollback on backend sync failure via `setPlaybackTempo()`.
- Add live keyboard tempo shortcuts and an `adjustTempoByStep()` helper in `frontend/src/features/playback/index.ts` so `[` and `]` adjust the slider, call `engine.setTempoMultiplier()`, and POST the tempo to the backend for sync.
- Add unit tests for the new scheduler: `scheduleNotes()` timing checks at `75%` and `50%` tempo in `frontend/src/playback/engine.test.ts`.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` with both passing successfully.
- Ran full Python tests with `uv run pytest -v`, which failed during collection in this environment due to missing native dependencies (`PortAudio`) and `torch` not installed; these failures are environmental and unrelated to the frontend changes introduced here.
- Ran frontend unit tests: `cd frontend && npx vitest run src/playback/engine.test.ts` which passed (the added `scheduleNotes` tests succeed).
- Ran `cd frontend && npm test` / full `vitest` which showed unrelated frontend test failures in other modules and a separate `npm run build` that failed due to pre-existing unused-symbol TypeScript errors in `src/pitch/overlay.*` (these are not part of this change).
- Captured an updated UI screenshot of the tempo control in the toolbar while the dev server was running to validate the UI change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b683773bb08327a653effe23e8a7b9)