### PR TITLE
feat: voice type detection from session range and preflight suggestions

### DIFF
--- a/frontend/src/features/audio-preflight/index.ts
+++ b/frontend/src/features/audio-preflight/index.ts
@@ -2,11 +2,16 @@ import { type Feature } from '../../feature-types';
 import {
   loadPreflightDeviceId,
   loadPreflightLatencyMs,
+  loadOctaveCompensationEnabled,
+  loadUserVoiceTypeId,
   markAudioPreflightComplete,
+  persistOctaveCompensationEnabled,
   persistPreflightDeviceId,
   persistPreflightLatencyMs,
+  persistUserVoiceTypeId,
   registerAudioPreflightOpener,
 } from '../../services/audio-preflight';
+import { VOICE_TYPES, getVoiceTypeById } from '../../pitch/voice-type';
 
 interface BrowserAudioInputDevice {
   deviceId: string;
@@ -30,10 +35,32 @@ let latencyValueEl: HTMLSpanElement | null = null;
 let errorEl: HTMLDivElement | null = null;
 let testButtonEl: HTMLButtonElement | null = null;
 let continueButtonEl: HTMLButtonElement | null = null;
+let voiceTypeSelectEl: HTMLSelectElement | null = null;
+let voiceTypeSuggestionEl: HTMLDivElement | null = null;
+let octaveCompCheckboxEl: HTMLInputElement | null = null;
 const METER_GAIN_SCALE = 140;
 
 let selectedDeviceId: string | null = loadPreflightDeviceId();
+let selectedVoiceTypeId: string | null = loadUserVoiceTypeId();
 let isMonitoring = false;
+
+function applyVoiceTypeSuggestionFromEvent(event: Event): void {
+  const custom = event as CustomEvent<{ suggestedVoiceTypeId: string; message: string }>;
+  const suggestedVoiceType = getVoiceTypeById(custom.detail.suggestedVoiceTypeId);
+  if (!voiceTypeSuggestionEl || !suggestedVoiceType) return;
+  voiceTypeSuggestionEl.textContent = custom.detail.message;
+
+  if (!selectedVoiceTypeId) {
+    selectedVoiceTypeId = suggestedVoiceType.id;
+    persistUserVoiceTypeId(selectedVoiceTypeId);
+    if (voiceTypeSelectEl) voiceTypeSelectEl.value = selectedVoiceTypeId;
+  }
+
+  if (suggestedVoiceType.male && octaveCompCheckboxEl && !loadOctaveCompensationEnabled()) {
+    octaveCompCheckboxEl.checked = true;
+    persistOctaveCompensationEnabled(true);
+  }
+}
 
 function setError(message: string): void {
   if (errorEl) errorEl.textContent = message;
@@ -230,6 +257,15 @@ function buildModal(): HTMLDivElement {
           <span id="audio-preflight-latency-value"></span>
         </div>
       </div>
+      <div class="audio-preflight-row">
+        <label for="audio-preflight-voice-type">Voice type</label>
+        <select id="audio-preflight-voice-type"></select>
+      </div>
+      <div id="audio-preflight-voice-suggestion" class="audio-preflight-status">Voice type suggestion: complete one session to get a recommendation.</div>
+      <div class="audio-preflight-row">
+        <label for="audio-preflight-octave-comp">Octave compensation</label>
+        <input id="audio-preflight-octave-comp" type="checkbox" />
+      </div>
       <div class="audio-preflight-tip">🎧 Use headphones to avoid feedback and mic bleed.</div>
       <div id="audio-preflight-error" class="audio-preflight-error" role="alert"></div>
       <div class="audio-preflight-actions">
@@ -310,6 +346,9 @@ function mount(_slot: HTMLElement): void {
   errorEl = document.getElementById('audio-preflight-error') as HTMLDivElement;
   testButtonEl = document.getElementById('audio-preflight-test') as HTMLButtonElement;
   continueButtonEl = document.getElementById('audio-preflight-continue') as HTMLButtonElement;
+  voiceTypeSelectEl = document.getElementById('audio-preflight-voice-type') as HTMLSelectElement;
+  voiceTypeSuggestionEl = document.getElementById('audio-preflight-voice-suggestion') as HTMLDivElement;
+  octaveCompCheckboxEl = document.getElementById('audio-preflight-octave-comp') as HTMLInputElement;
 
   const requestButton = document.getElementById('audio-preflight-request') as HTMLButtonElement;
   const latencyEl = document.getElementById('audio-preflight-latency') as HTMLInputElement;
@@ -317,6 +356,13 @@ function mount(_slot: HTMLElement): void {
   const latencyMs = loadPreflightLatencyMs();
   latencyEl.value = String(latencyMs);
   latencyValueEl.textContent = `${latencyMs} ms`;
+
+  voiceTypeSelectEl.innerHTML = [
+    '<option value="">Not set</option>',
+    ...VOICE_TYPES.map((type) => `<option value="${type.id}">${type.label}</option>`),
+  ].join('');
+  if (selectedVoiceTypeId) voiceTypeSelectEl.value = selectedVoiceTypeId;
+  octaveCompCheckboxEl.checked = loadOctaveCompensationEnabled();
 
   requestButton.addEventListener('click', () => {
     void requestPermissionAndDevices();
@@ -334,6 +380,15 @@ function mount(_slot: HTMLElement): void {
     if (latencyValueEl) latencyValueEl.textContent = `${value} ms`;
   });
 
+  voiceTypeSelectEl.addEventListener('change', () => {
+    selectedVoiceTypeId = voiceTypeSelectEl?.value || null;
+    persistUserVoiceTypeId(selectedVoiceTypeId);
+  });
+
+  octaveCompCheckboxEl.addEventListener('change', () => {
+    persistOctaveCompensationEnabled(Boolean(octaveCompCheckboxEl?.checked));
+  });
+
   testButtonEl.addEventListener('click', () => {
     void toggleMicTest();
   });
@@ -343,6 +398,7 @@ function mount(_slot: HTMLElement): void {
   });
 
   registerAudioPreflightOpener(openModal);
+  window.addEventListener('voice-type-suggested', applyVoiceTypeSuggestionFromEvent as EventListener);
 }
 
 function unmount(): void {
@@ -350,6 +406,7 @@ function unmount(): void {
   // monitorCtx is already closed and nulled by cleanupMonitor()
   modalEl?.remove();
   modalEl = null;
+  window.removeEventListener('voice-type-suggested', applyVoiceTypeSuggestionFromEvent as EventListener);
 }
 
 export const __audioPreflightInternals = {

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -28,12 +28,14 @@ import { PitchTimelineSync } from '../../pitch/timeline-sync';
 import { parsePitchSocketMessage, reconnectDelayMs } from '../../pitch/socket';
 import { midiToFrequency, midiToNoteName } from '../../pitch/note-name';
 import { SessionRangeTracker } from '../../pitch/session-range';
+import { classifyVoiceType, getVoiceTypeById } from '../../pitch/voice-type';
 import { elapsedToBeat } from '../../score/timing';
 import { type NoteModel } from '../../score/renderer';
 import { PhraseSummaryTracker, type PhraseSummary } from '../../pitch/phrase-summary';
 import { resolveSelectedDeviceId, type AudioInputDevice } from '../../audio/devices';
 import { PracticeRecorder } from '../../audio/recorder';
 import { type Feature } from '../../feature-types';
+import { loadUserVoiceTypeId } from '../../services/audio-preflight';
 
 // ── Module-level singletons (survive score reloads) ───────────────────────────
 
@@ -58,6 +60,7 @@ let recordingError: string | null = null;
 let phraseSummaryTracker: PhraseSummaryTracker | null = null;
 let sessionRangeSummaryText = 'Last session range: —';
 let wasPlayingLastTick = false;
+let hasSuggestedVoiceType = false;
 const sessionRangeTracker = new SessionRangeTracker();
 const timelineSync = new PitchTimelineSync();
 let playbackSyncUnsubscribe: (() => void) | null = null;
@@ -124,6 +127,21 @@ function finalizeSessionRangeSummary(): void {
     const high = midiToNoteName(summary.highMidi);
     sessionRangeSummaryText =
       `Last session range: ${low} → ${high} (${summary.semitoneSpan} semitones, ${summary.octaveSpan.toFixed(2)} octaves)`;
+
+    const suggested = classifyVoiceType({
+      lowestMidi: summary.lowMidi,
+      highestMidi: summary.highMidi,
+      stableNoteCount: summary.stableNoteCount,
+    });
+    if (suggested && !hasSuggestedVoiceType && !getVoiceTypeById(loadUserVoiceTypeId())) {
+      window.dispatchEvent(new CustomEvent('voice-type-suggested', {
+        detail: {
+          suggestedVoiceTypeId: suggested.id,
+          message: `Your range suggests you may be a ${suggested.label} (${low}–${high}). Does this look right?`,
+        },
+      }));
+      hasSuggestedVoiceType = true;
+    }
   }
   updateSessionRangeSummary();
 }
@@ -455,6 +473,7 @@ function mount(_slot: HTMLElement): void {
     clearPhraseSummaryPanel();
     updatePitchReadout();
     wasPlayingLastTick = false;
+    hasSuggestedVoiceType = false;
     sessionRangeTracker.reset();
     updateSessionRangeReadout();
   });
@@ -470,6 +489,7 @@ function mount(_slot: HTMLElement): void {
     lastPitchFrame = null;
     pitchGraphNowSec = 0;
     wasPlayingLastTick = false;
+    hasSuggestedVoiceType = false;
     sessionRangeTracker.reset();
     clearPhraseSummaryPanel();
     updatePitchReadout();

--- a/frontend/src/pitch/session-range.ts
+++ b/frontend/src/pitch/session-range.ts
@@ -6,6 +6,7 @@ export interface SessionRange {
 export interface SessionRangeSummary extends SessionRange {
   semitoneSpan: number;
   octaveSpan: number;
+  stableNoteCount: number;
 }
 
 export interface SessionRangeTrackerOptions {
@@ -27,6 +28,8 @@ export class SessionRangeTracker {
 
   private lowMidi: number | null = null;
   private highMidi: number | null = null;
+  private stableNoteCount = 0;
+  private lastStableMidi: number | null = null;
 
   private candidateMidi: number | null = null;
   private candidateSinceMs: number | null = null;
@@ -68,6 +71,8 @@ export class SessionRangeTracker {
   reset(): void {
     this.lowMidi = null;
     this.highMidi = null;
+    this.stableNoteCount = 0;
+    this.lastStableMidi = null;
     this.resetCandidate();
   }
 
@@ -85,10 +90,16 @@ export class SessionRangeTracker {
       highMidi: this.highMidi,
       semitoneSpan,
       octaveSpan: semitoneSpan / 12,
+      stableNoteCount: this.stableNoteCount,
     };
   }
 
   private commitStableMidi(stableMidi: number): boolean {
+    if (this.lastStableMidi !== stableMidi) {
+      this.stableNoteCount += 1;
+      this.lastStableMidi = stableMidi;
+    }
+
     let changed = false;
     if (this.lowMidi === null || stableMidi < this.lowMidi) {
       this.lowMidi = stableMidi;

--- a/frontend/src/pitch/voice-type.test.ts
+++ b/frontend/src/pitch/voice-type.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyVoiceType, getVoiceTypeById } from './voice-type';
+
+describe('classifyVoiceType', () => {
+  it('classifies bass ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 41, highestMidi: 63, stableNoteCount: 12 });
+    expect(result?.id).toBe('bass');
+  });
+
+  it('classifies baritone ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 44, highestMidi: 66, stableNoteCount: 12 });
+    expect(result?.id).toBe('baritone');
+  });
+
+  it('classifies tenor ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 49, highestMidi: 71, stableNoteCount: 12 });
+    expect(result?.id).toBe('tenor');
+  });
+
+  it('classifies alto ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 55, highestMidi: 78, stableNoteCount: 12 });
+    expect(result?.id).toBe('alto');
+  });
+
+  it('classifies mezzo-soprano ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 58, highestMidi: 80, stableNoteCount: 12 });
+    expect(result?.id).toBe('mezzo-soprano');
+  });
+
+  it('classifies soprano ranges', () => {
+    const result = classifyVoiceType({ lowestMidi: 61, highestMidi: 83, stableNoteCount: 12 });
+    expect(result?.id).toBe('soprano');
+  });
+
+  it('returns null when there are not enough stable notes or span', () => {
+    expect(classifyVoiceType({ lowestMidi: 48, highestMidi: 72, stableNoteCount: 9 })).toBeNull();
+    expect(classifyVoiceType({ lowestMidi: 60, highestMidi: 64, stableNoteCount: 15 })).toBeNull();
+  });
+});
+
+describe('getVoiceTypeById', () => {
+  it('returns voice type for known id', () => {
+    expect(getVoiceTypeById('tenor')?.label).toBe('Tenor');
+  });
+
+  it('returns null for unknown id', () => {
+    expect(getVoiceTypeById('countertenor')).toBeNull();
+  });
+});

--- a/frontend/src/pitch/voice-type.ts
+++ b/frontend/src/pitch/voice-type.ts
@@ -1,0 +1,54 @@
+export type VoiceTypeId = 'bass' | 'baritone' | 'tenor' | 'alto' | 'mezzo-soprano' | 'soprano';
+
+export interface VoiceType {
+  id: VoiceTypeId;
+  label: string;
+  lowMidi: number;
+  highMidi: number;
+  male: boolean;
+}
+
+export interface VoiceTypeClassificationInput {
+  lowestMidi: number;
+  highestMidi: number;
+  stableNoteCount: number;
+}
+
+export const VOICE_TYPES: VoiceType[] = [
+  { id: 'bass', label: 'Bass', lowMidi: 40, highMidi: 64, male: true },
+  { id: 'baritone', label: 'Baritone', lowMidi: 43, highMidi: 67, male: true },
+  { id: 'tenor', label: 'Tenor', lowMidi: 48, highMidi: 72, male: true },
+  { id: 'alto', label: 'Alto', lowMidi: 55, highMidi: 79, male: false },
+  { id: 'mezzo-soprano', label: 'Mezzo-soprano', lowMidi: 57, highMidi: 81, male: false },
+  { id: 'soprano', label: 'Soprano', lowMidi: 60, highMidi: 84, male: false },
+];
+
+const MIN_STABLE_NOTES = 10;
+const MIN_SEMITONE_SPAN = 5;
+
+export function classifyVoiceType(input: VoiceTypeClassificationInput): VoiceType | null {
+  if (!Number.isFinite(input.lowestMidi) || !Number.isFinite(input.highestMidi)) return null;
+  if (input.stableNoteCount < MIN_STABLE_NOTES) return null;
+  const span = input.highestMidi - input.lowestMidi;
+  if (!Number.isFinite(span) || span < MIN_SEMITONE_SPAN) return null;
+
+  const midpoint = (input.lowestMidi + input.highestMidi) / 2;
+  let bestMatch: VoiceType | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+
+  for (const voiceType of VOICE_TYPES) {
+    const voiceMidpoint = (voiceType.lowMidi + voiceType.highMidi) / 2;
+    const distance = Math.abs(midpoint - voiceMidpoint);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      bestMatch = voiceType;
+    }
+  }
+
+  return bestMatch;
+}
+
+export function getVoiceTypeById(id: string | null): VoiceType | null {
+  if (!id) return null;
+  return VOICE_TYPES.find((voiceType) => voiceType.id === id) ?? null;
+}

--- a/frontend/src/services/audio-preflight.ts
+++ b/frontend/src/services/audio-preflight.ts
@@ -1,5 +1,7 @@
 const PRE_FLIGHT_DEVICE_KEY = 'sing-attune.preflight.deviceId';
 const PRE_FLIGHT_LATENCY_KEY = 'sing-attune.preflight.latencyMs';
+const USER_VOICE_TYPE_KEY = 'userVoiceType';
+const USER_OCTAVE_COMP_KEY = 'sing-attune.preflight.octaveCompensation';
 
 const DEFAULT_LATENCY_MS = 0;
 
@@ -62,4 +64,33 @@ export function persistPreflightLatencyMs(value: number): void {
   if (!storage) return;
   const clamped = Math.round(Math.min(500, Math.max(-250, value)));
   storage.setItem(PRE_FLIGHT_LATENCY_KEY, String(clamped));
+}
+
+export function loadUserVoiceTypeId(): string | null {
+  const storage = getStorage();
+  if (!storage) return null;
+  const value = storage.getItem(USER_VOICE_TYPE_KEY);
+  return value && value.trim() !== '' ? value : null;
+}
+
+export function persistUserVoiceTypeId(voiceTypeId: string | null): void {
+  const storage = getStorage();
+  if (!storage) return;
+  if (!voiceTypeId) {
+    storage.removeItem(USER_VOICE_TYPE_KEY);
+    return;
+  }
+  storage.setItem(USER_VOICE_TYPE_KEY, voiceTypeId);
+}
+
+export function loadOctaveCompensationEnabled(): boolean {
+  const storage = getStorage();
+  if (!storage) return false;
+  return storage.getItem(USER_OCTAVE_COMP_KEY) === '1';
+}
+
+export function persistOctaveCompensationEnabled(enabled: boolean): void {
+  const storage = getStorage();
+  if (!storage) return;
+  storage.setItem(USER_OCTAVE_COMP_KEY, enabled ? '1' : '0');
 }


### PR DESCRIPTION
### Motivation
- Improve UX by inferring a singer's voice type from captured stable-note range to avoid incorrect part selection and confusing pitch feedback.  
- Use the inference to auto-suggest octave compensation for male voices while leaving the user able to override any suggestion.  
- Gate inference on minimal data quality so suggestions are only offered when the session has enough stable notes and span.

### Description
- Add a new classifier module `frontend/src/pitch/voice-type.ts` implementing Fach ranges (bass→soprano), midpoint-distance matching, male metadata, and gate rules (`MIN_STABLE_NOTES` and `MIN_SEMITONE_SPAN`).  
- Extend `SessionRangeTracker` (`frontend/src/pitch/session-range.ts`) to count distinct stable notes and expose `stableNoteCount` in the session summary so classification only triggers after sufficient data.  
- On session completion emit a `voice-type-suggested` event from the pitch overlay (`frontend/src/features/pitch-overlay/index.ts`) when eligible, without overriding an existing user setting.  
- Persist user voice-type and octave-compensation preference via new APIs in `frontend/src/services/audio-preflight.ts` and surface a voice-type selector, suggestion text, and octave-compensation checkbox in the Audio Preflight modal (`frontend/src/features/audio-preflight/index.ts`), auto-suggesting octave compensation for inferred male voice types (not forcing it).  
- Add unit tests `frontend/src/pitch/voice-type.test.ts` covering all 6 voice types and guard conditions.

### Testing
- Ran frontend unit tests for the new/related components: `npx vitest run src/pitch/voice-type.test.ts src/pitch/session-range.test.ts src/features/audio-preflight/index.test.ts` and they passed.  
- Ran lint checks on the backend with `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which both passed.  
- Full backend `uv run pytest -v` failed in this environment due to missing system dependencies (`PortAudio`) and `torch` not being installed, which are environment limitations unrelated to these changes.  
- Full frontend test run (`npm test`) and `npm run build` surfaced pre-existing unrelated test and TypeScript errors in other areas of the repository; the voice-type-focused tests and the added tests passed locally as noted.  
- Captured a visual snapshot of the updated preflight modal with the voice-type suggestion (artifact attached during validation run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b683a98db48327991d1343967f2738)

Closes #102 