### PR TITLE
fix: wire preflight latency offset into playback engine

### DIFF
--- a/frontend/src/playback/engine.test.ts
+++ b/frontend/src/playback/engine.test.ts
@@ -99,6 +99,81 @@ describe('scheduleNotes', () => {
     expect(events[0].startAt).toBeCloseTo(10, 6);
     expect(events[1].startAt).toBeCloseTo(12, 6);
   });
+
+  it('applies positive latency offset to event start times', () => {
+    const events = scheduleNotes(notes, BPM120, 0, 10, 1, 0.2);
+    expect(events[0].startAt).toBeCloseTo(10.2, 6);
+    expect(events[1].startAt).toBeCloseTo(11.2, 6);
+  });
+
+  it('applies negative latency offset to event start times', () => {
+    const events = scheduleNotes(notes, BPM120, 0, 10, 1, -0.1);
+    expect(events[0].startAt).toBeCloseTo(9.9, 6);
+    expect(events[1].startAt).toBeCloseTo(10.9, 6);
+  });
+});
+
+describe('PlaybackEngine latency compensation', () => {
+  it('loads preflight latency fresh on each play call', () => {
+    const starts: number[] = [];
+
+    class FakeBufferSource {
+      buffer: AudioBuffer | null = null;
+      detune = { value: 0 };
+      connect(): void {}
+      start(when?: number): void { starts.push(when ?? 0); }
+      stop(): void {}
+    }
+
+    class FakeAudioContext {
+      currentTime = 100;
+      state: AudioContextState = 'running';
+      destination = {} as AudioDestinationNode;
+      createBufferSource(): AudioBufferSourceNode {
+        return new FakeBufferSource() as unknown as AudioBufferSourceNode;
+      }
+      createGain(): GainNode {
+        return { gain: { value: 1 }, connect(): void {} } as unknown as GainNode;
+      }
+      createOscillator(): OscillatorNode {
+        return {} as OscillatorNode;
+      }
+      resume(): Promise<void> {
+        return Promise.resolve();
+      }
+    }
+
+    class FakeSoundfont {
+      getBuffer(): AudioBuffer {
+        return {} as AudioBuffer;
+      }
+      getNearestSampledMidi(midi: number): number {
+        return midi;
+      }
+    }
+
+    window.localStorage.setItem('sing-attune.preflight.latencyMs', '200');
+    const ctx = new FakeAudioContext();
+    const engine = new PlaybackEngine(
+      ctx as unknown as AudioContext,
+      new FakeSoundfont() as unknown as import('./soundfont').SoundfontLoader,
+    );
+    const notes: import('../score/renderer').NoteModel[] = [
+      { midi: 60, beat_start: 0, duration: 1, measure: 1, part: 'PART I', lyric: null },
+    ];
+
+    engine.schedule(notes, BPM120, 'PART I', 1);
+    engine.play(0);
+    expect(starts[0]).toBeCloseTo(100.3, 6);
+
+    engine.stop();
+    ctx.currentTime = 200;
+    window.localStorage.setItem('sing-attune.preflight.latencyMs', '-100');
+    engine.play(0);
+    expect(starts[1]).toBeCloseTo(200.005, 6);
+
+    window.localStorage.removeItem('sing-attune.preflight.latencyMs');
+  });
 });
 
 describe('PlaybackEngine part selection', () => {

--- a/frontend/src/playback/engine.ts
+++ b/frontend/src/playback/engine.ts
@@ -30,6 +30,7 @@
  */
 import { elapsedToBeat } from '../score/timing';
 import type { NoteModel, TempoMark } from '../score/renderer';
+import { loadPreflightLatencyMs } from '../services/audio-preflight';
 import type { SoundfontLoader } from './soundfont';
 
 /** Seconds per beat at the given BPM */
@@ -81,6 +82,7 @@ export function scheduleNotes(
   fromBeat: number,
   originTime: number,
   tempoMultiplier: number,
+  latencyOffsetS = 0,
 ): ScheduledNoteEvent[] {
   const originOffsetS = beatToSeconds(fromBeat, tempoMarks, tempoMultiplier);
   return notes
@@ -94,7 +96,7 @@ export function scheduleNotes(
         RELEASE_TAIL_S;
       return {
         note,
-        startAt: originTime + noteStartOffsetS,
+        startAt: originTime + noteStartOffsetS + latencyOffsetS,
         durationS: noteDurS,
       };
     });
@@ -134,6 +136,7 @@ export class PlaybackEngine {
   private _tempoMarks: TempoMark[] = [];
   private _tempoMultiplier = 1;
   private _transposeSemitones = 0;
+  private _latencyOffsetS = 0;
 
   constructor(ctx: AudioContext, sf: SoundfontLoader) {
     this.ctx = ctx;
@@ -214,6 +217,7 @@ export class PlaybackEngine {
   play(fromBeat = 0): void {
     if (this._state === 'playing') return;
     if (this.ctx.state === 'suspended') void this.ctx.resume();
+    this._latencyOffsetS = loadPreflightLatencyMs() / 1000;
     this._startBeat = fromBeat;
     this._startAudioTime = this.ctx.currentTime + SCHEDULE_OFFSET_S;
     this._scheduleFrom(fromBeat, this._startAudioTime);
@@ -345,22 +349,13 @@ export class PlaybackEngine {
    * behind ctx.currentTime) are also skipped to avoid scheduling overruns.
    */
   private _scheduleFrom(fromBeat: number, originTime: number): void {
-    const originOffsetS = beatToSeconds(fromBeat, this._tempoMarks, this._tempoMultiplier);
-
-    for (const note of this._allNotes) {
-      // Skip notes that ended before the resume point
-      if (note.beat_start + note.duration <= fromBeat) continue;
-
-      const noteStartOffsetS =
-        beatToSeconds(note.beat_start, this._tempoMarks, this._tempoMultiplier) - originOffsetS;
-      const startAt = originTime + noteStartOffsetS;
-
     const events = scheduleNotes(
-      this._notes,
+      this._allNotes,
       this._tempoMarks,
       fromBeat,
       originTime,
       this._tempoMultiplier,
+      this._latencyOffsetS,
     );
 
     for (const event of events) {


### PR DESCRIPTION
### Motivation
- The persisted pre-flight latency slider value was stored but never applied to playback scheduling, so UI changes had no effect on note timing.
- Playback must read the latest latency value at each `play()` and apply it consistently across play, pause/resume, and seek so latency compensation actually shifts audio onset relative to the score cursor.

### Description
- Import `loadPreflightLatencyMs()` and load the persisted latency in `PlaybackEngine.play()` into a new `_latencyOffsetS` (seconds) field so each `play()` reads the latest value.
- Extend `scheduleNotes(...)` with an additional `latencyOffsetS` parameter and add that offset to each event's absolute `startAt` time so positive values delay and negative values advance playback.
- Update `_scheduleFrom(...)` and scheduling paths to pass `this._latencyOffsetS` and use `_allNotes` when building events so seek/reschedule operations use the active compensation.
- Add unit tests in `frontend/src/playback/engine.test.ts` that validate positive/negative scheduling offsets and that latency is reloaded on each `play()` call.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which both passed successfully.
- Ran `cd frontend && npx vitest run src/playback/engine.test.ts`; the updated engine tests passed (24/24).
- Ran full frontend test suite via `cd frontend && npm test`, which revealed 3 pre-existing, unrelated failing tests in the codebase (`progress-history` and `timeline-sync`); these failures are unrelated to this change.
- Ran `uv run pytest -v` for backend tests but collection failed in this environment due to missing system dependencies (PortAudio) and missing `torch`, so backend test run could not complete here.
- Attempted `cd frontend && npm run build`; build fails in this environment due to unrelated TypeScript errors elsewhere in the project (pre-existing issues).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6909ae7248327b43e107fa3e69438)

Closes #190 