### PR TITLE
feat: Media Session API integration for hardware transport controls

### DIFF
--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -15,7 +15,7 @@
  * services/cursor-projection.ts so pitch-overlay can read it without
  * importing from this feature.
  */
-import { onScoreCleared, onScoreLoaded, getSession } from '../../services/score-session';
+import { onPartChanged, onScoreCleared, onScoreLoaded, getSession } from '../../services/score-session';
 import { setStatus } from '../../services/backend';
 import { recordBeatSample, resetProjection, getCursorX } from '../../services/cursor-projection';
 import { finishPracticeSessionCapture, startPracticeSessionCapture } from '../../services/progress-history';
@@ -25,6 +25,7 @@ import { sessionSummaryTracker, type SessionSummary } from '../../practice/sessi
 import { type Feature } from '../../feature-types';
 import { ensureAudioPreflightReady } from '../../services/audio-preflight';
 import { clearLoopRegion, getLoopRegion, setLoopEnd, setLoopStart } from '../../services/loop-region';
+import { installMediaSession, updateMediaSessionMetadata, updateMediaSessionState } from '../../media-session';
 
 // ── Cursor RAF ──────────────────────────────────────────────────────────────────
 
@@ -59,8 +60,48 @@ async function restartLoopPlayback(): Promise<void> {
 let cursorRafId: number | null = null;
 let unsubscribeScoreLoaded: (() => void) | null = null;
 let unsubscribeScoreCleared: (() => void) | null = null;
+let unsubscribePartChanged: (() => void) | null = null;
 let removeKeydownListener: (() => void) | null = null;
 let loopSeekInFlight = false;
+
+function getCurrentBpm(): number {
+  const session = getSession();
+  if (!session) return 120;
+  const firstTempoMark = session.model.tempo_marks[0];
+  return firstTempoMark?.bpm ?? 120;
+}
+
+function secondsToBeats(seconds: number): number {
+  const session = getSession();
+  if (!session) return 0;
+  const bpm = getCurrentBpm();
+  return seconds * (bpm * session.engine.tempoMultiplier / 60);
+}
+
+async function seekToBeat(targetBeat: number): Promise<void> {
+  const session = getSession();
+  if (!session) return;
+  const { engine, cursor, model } = session;
+  const clampedBeat = Math.max(0, Math.min(model.total_beats, targetBeat));
+  try {
+    const audioTimeSec = engine.ctx.currentTime;
+    const response = await seekPlayback(beatToMs(clampedBeat, model, engine.tempoMultiplier));
+    emitPlaybackSyncEvent({
+      type: 'seek',
+      tMs: response.t_ms,
+      audioTimeSec,
+      syncOffsetMs: null,
+    });
+  } catch (err) {
+    setStatus(`seek failed: ${String(err)}`, 'error');
+    console.error('Seek failed:', err);
+    return;
+  }
+
+  engine.seekToBeat(clampedBeat);
+  cursor.seekToBeat(clampedBeat);
+  if (engine.state !== 'playing') stopCursorRaf();
+}
 
 function startCursorRaf(): void {
   stopCursorRaf();
@@ -99,27 +140,11 @@ function stopCursorRaf(): void {
 async function seekByBeats(delta: number): Promise<void> {
   const session = getSession();
   if (!session) return;
-  const { engine, cursor, model } = session;
+  const { engine, model } = session;
   const stepBeats = model.time_signatures[0]?.numerator ?? 4;
   const targetBeat = Math.max(0,
     Math.min(model.total_beats, engine.currentBeat + delta * stepBeats));
-  try {
-    const audioTimeSec = engine.ctx.currentTime;
-    const response = await seekPlayback(beatToMs(targetBeat, model, engine.tempoMultiplier));
-    emitPlaybackSyncEvent({
-      type: 'seek',
-      tMs: response.t_ms,
-      audioTimeSec,
-      syncOffsetMs: null,
-    });
-  } catch (err) {
-    setStatus(`seek failed: ${String(err)}`, 'error');
-    console.error('Seek failed:', err);
-    return;
-  }
-  engine.seekToBeat(targetBeat);
-  cursor.seekToBeat(targetBeat);
-  if (engine.state !== 'playing') stopCursorRaf();
+  await seekToBeat(targetBeat);
 }
 
 
@@ -212,6 +237,27 @@ function mount(_slot: HTMLElement): void {
   const summaryRetry     = document.getElementById('btn-summary-retry')  as HTMLButtonElement;
   const summaryReplay    = document.getElementById('btn-summary-replay') as HTMLButtonElement;
 
+  installMediaSession({
+    play: () => {
+      const session = getSession();
+      if (!session || session.engine.state === 'playing') return;
+      btnPlay.click();
+    },
+    pause: () => {
+      const session = getSession();
+      if (!session || session.engine.state !== 'playing') return;
+      btnPause.click();
+    },
+    stop: () => {
+      const session = getSession();
+      if (!session) return;
+      btnStop.click();
+    },
+    seekTo: (seconds) => {
+      void seekToBeat(secondsToBeats(seconds));
+    },
+  });
+
 
   function syncTransportButtons(): void {
     const session = getSession();
@@ -243,11 +289,15 @@ function mount(_slot: HTMLElement): void {
     btnPause.innerHTML = '&#9646;&#9646; Pause';
   }
 
-  const unsubscribeLoaded = onScoreLoaded(() => { syncTransportButtons(); });
+  const unsubscribeLoaded = onScoreLoaded((session) => {
+    updateMediaSessionMetadata(session.model.title, session.selectedPart);
+    syncTransportButtons();
+  });
   const unsubscribeCleared = onScoreCleared(() => {
     stopCursorRaf();
     finishPracticeSessionCapture();
     clearLoopRegion();
+    updateMediaSessionState('none');
     syncTransportButtons();
   });
 
@@ -271,11 +321,19 @@ function mount(_slot: HTMLElement): void {
 
   unsubscribeScoreLoaded?.();
   unsubscribeScoreCleared?.();
-  unsubscribeScoreLoaded = onScoreLoaded(() => { syncTransportButtons(); });
+  unsubscribePartChanged?.();
+  unsubscribeScoreLoaded = onScoreLoaded((session) => {
+    updateMediaSessionMetadata(session.model.title, session.selectedPart);
+    syncTransportButtons();
+  });
+  unsubscribePartChanged = onPartChanged((session) => {
+    updateMediaSessionMetadata(session.model.title, session.selectedPart);
+  });
   unsubscribeScoreCleared = onScoreCleared(() => {
     stopCursorRaf();
     finishPracticeSessionCapture();
     clearLoopRegion();
+    updateMediaSessionState('none');
     syncTransportButtons();
   });
 
@@ -317,6 +375,7 @@ function mount(_slot: HTMLElement): void {
         cursor.osmd.cursor.show();
       }
       engine.play(fromBeat);
+      updateMediaSessionState('playing');
       startCursorRaf();
       syncTransportButtons();
     } catch (err) {
@@ -340,6 +399,7 @@ function mount(_slot: HTMLElement): void {
           syncOffsetMs: null,
         });
         engine.pause();
+        updateMediaSessionState('paused');
         stopCursorRaf();
       } else if (engine.state === 'paused') {
         const audioTimeSec = engine.ctx.currentTime;
@@ -351,6 +411,7 @@ function mount(_slot: HTMLElement): void {
           syncOffsetMs: null,
         });
         engine.play(engine.startBeat);
+        updateMediaSessionState('playing');
         startCursorRaf();
       }
       syncTransportButtons();
@@ -367,6 +428,7 @@ function mount(_slot: HTMLElement): void {
       const audioTimeSec = session.engine.ctx.currentTime;
       const response = await postPlayback('/playback/stop');
       session.engine.stop();
+      updateMediaSessionState('none');
       finishPracticeSessionCapture();
       emitPlaybackSyncEvent({
         type: 'stop',
@@ -404,6 +466,7 @@ function mount(_slot: HTMLElement): void {
       console.error('Rewind failed:', err);
     }
     session.engine.stop();
+    updateMediaSessionState('none');
     finishPracticeSessionCapture();
     stopCursorRaf();
     session.cursor.stop();
@@ -486,6 +549,8 @@ function unmount(): void {
   unsubscribeScoreLoaded = null;
   unsubscribeScoreCleared?.();
   unsubscribeScoreCleared = null;
+  unsubscribePartChanged?.();
+  unsubscribePartChanged = null;
   removeKeydownListener?.();
   removeKeydownListener = null;
 }

--- a/frontend/src/media-session.test.ts
+++ b/frontend/src/media-session.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  installMediaSession,
+  updateMediaSessionMetadata,
+  updateMediaSessionState,
+  type MediaSessionHandlers,
+} from './media-session';
+
+type ActionName = 'play' | 'pause' | 'stop' | 'seekto';
+
+describe('media-session', () => {
+  beforeEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('gracefully no-ops when media session is unsupported', () => {
+    vi.stubGlobal('navigator', {});
+
+    expect(() => installMediaSession({ play() {}, pause() {}, stop() {} })).not.toThrow();
+    expect(() => updateMediaSessionMetadata('Score', 'Tenor')).not.toThrow();
+    expect(() => updateMediaSessionState('playing')).not.toThrow();
+  });
+
+  it('installs handlers and updates metadata/state when supported', () => {
+    const actionHandlers = new Map<ActionName, (...args: unknown[]) => void>();
+    const mediaSession = {
+      metadata: null,
+      playbackState: 'none' as MediaSessionPlaybackState,
+      setActionHandler: vi.fn((action: ActionName, handler: (...args: unknown[]) => void) => {
+        actionHandlers.set(action, handler);
+      }),
+    };
+    const mediaMetadataCtor = vi.fn((meta) => meta);
+
+    vi.stubGlobal('navigator', { mediaSession });
+    vi.stubGlobal('MediaMetadata', mediaMetadataCtor);
+
+    const handlers: MediaSessionHandlers = {
+      play: vi.fn(),
+      pause: vi.fn(),
+      stop: vi.fn(),
+      seekTo: vi.fn(),
+    };
+
+    installMediaSession(handlers);
+    updateMediaSessionMetadata('Ave Maria', 'Soprano 1');
+    updateMediaSessionState('playing');
+
+    actionHandlers.get('play')?.();
+    actionHandlers.get('pause')?.();
+    actionHandlers.get('stop')?.();
+    actionHandlers.get('seekto')?.({ seekTime: 42 });
+
+    expect(handlers.play).toHaveBeenCalledTimes(1);
+    expect(handlers.pause).toHaveBeenCalledTimes(1);
+    expect(handlers.stop).toHaveBeenCalledTimes(1);
+    expect(handlers.seekTo).toHaveBeenCalledWith(42);
+    expect(mediaMetadataCtor).toHaveBeenCalledWith({
+      title: 'Ave Maria',
+      artist: 'Soprano 1',
+      album: 'sing-attune',
+    });
+    expect(mediaSession.playbackState).toBe('playing');
+  });
+});

--- a/frontend/src/media-session.ts
+++ b/frontend/src/media-session.ts
@@ -1,0 +1,39 @@
+export interface MediaSessionHandlers {
+  play(): void;
+  pause(): void;
+  stop(): void;
+  seekTo?(seconds: number): void;
+}
+
+function hasMediaSession(): boolean {
+  return 'mediaSession' in navigator;
+}
+
+export function installMediaSession(handlers: MediaSessionHandlers): void {
+  if (!hasMediaSession()) return;
+
+  navigator.mediaSession.setActionHandler('play', () => handlers.play());
+  navigator.mediaSession.setActionHandler('pause', () => handlers.pause());
+  navigator.mediaSession.setActionHandler('stop', () => handlers.stop());
+
+  if (handlers.seekTo) {
+    navigator.mediaSession.setActionHandler('seekto', (details) => {
+      if (details.seekTime != null) handlers.seekTo?.(details.seekTime);
+    });
+  }
+}
+
+export function updateMediaSessionMetadata(scoreTitle: string, partName: string): void {
+  if (!hasMediaSession()) return;
+
+  navigator.mediaSession.metadata = new MediaMetadata({
+    title: scoreTitle || 'sing-attune session',
+    artist: partName || '',
+    album: 'sing-attune',
+  });
+}
+
+export function updateMediaSessionState(state: MediaSessionPlaybackState): void {
+  if (!hasMediaSession()) return;
+  navigator.mediaSession.playbackState = state;
+}

--- a/frontend/src/playback/engine.ts
+++ b/frontend/src/playback/engine.ts
@@ -345,18 +345,8 @@ export class PlaybackEngine {
    * behind ctx.currentTime) are also skipped to avoid scheduling overruns.
    */
   private _scheduleFrom(fromBeat: number, originTime: number): void {
-    const originOffsetS = beatToSeconds(fromBeat, this._tempoMarks, this._tempoMultiplier);
-
-    for (const note of this._allNotes) {
-      // Skip notes that ended before the resume point
-      if (note.beat_start + note.duration <= fromBeat) continue;
-
-      const noteStartOffsetS =
-        beatToSeconds(note.beat_start, this._tempoMarks, this._tempoMultiplier) - originOffsetS;
-      const startAt = originTime + noteStartOffsetS;
-
     const events = scheduleNotes(
-      this._notes,
+      this._allNotes,
       this._tempoMarks,
       fromBeat,
       originTime,


### PR DESCRIPTION
### Motivation
- Expose browser Media Session integration so hardware media keys and OS transport controls can control playback and show session metadata for a better UX during headphone-required practice.

### Description
- Add `frontend/src/media-session.ts` with safe no-op behavior when `navigator.mediaSession` is unavailable and helpers `installMediaSession`, `updateMediaSessionMetadata`, and `updateMediaSessionState`.
- Wire media session into the playback feature by installing handlers on mount that delegate to existing transport flows, converting `seekto` seconds into beats using current BPM and `tempoMultiplier`, and updating metadata when a score or selected part changes via `onScoreLoaded` and `onPartChanged` subscriptions (`frontend/src/features/playback/index.ts`).
- Update playback transitions to keep `navigator.mediaSession.playbackState` in sync on `play`/`pause`/`resume`/`stop`/`rewind`/score-clear events by calling `updateMediaSessionState`.
- Fix scheduling bug in the playback engine by consistently using `scheduleNotes(this._allNotes, ...)` inside `PlaybackEngine._scheduleFrom` and remove the stale duplicated scheduling fragment (`frontend/src/playback/engine.ts`).
- Add unit tests for the media session module (`frontend/src/media-session.test.ts`) covering both unsupported and supported runtimes.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`; both passed.
- Ran `uv run pytest -v`; collection failed in this container due to missing native dependencies (`PortAudio`) and `torch` not present in the environment, so backend tests could not be fully exercised here.
- Ran targeted frontend tests: `cd frontend && npx vitest run src/media-session.test.ts src/playback/engine.test.ts`; both test files passed.
- Ran full frontend test suite `cd frontend && npm test`; suite ran but reported unrelated, pre-existing failures in `progress-history` and `timeline-sync` (not introduced by this change).
- Attempted `cd frontend && npm run build`; build failed due to existing TypeScript issues in unrelated files (`score-loader` / `pitch overlay`) that predate this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b69080452083279b7bf028ab3031c3)

Closes #150 