### PR TITLE
a11y: add pitch accuracy labels and non-colour trace encodings

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -707,7 +707,7 @@
       <section id="pitch-graph-panel" aria-label="Pitch graph panel">
         <div id="pitch-graph-header">
           <span id="pitch-graph-title">Pitch graph (C2–C6, 10s window)</span>
-          <span>Blue band: expected pitch &plusmn;50 cents &middot; Green trace/dot: within &plusmn;50 cents &middot; Red: out of tune &middot; Grey: no target</span>
+          <span>Blue band: expected pitch &plusmn;50 cents &middot; Green solid trace/dot: in tune &middot; Orange dashed trace/dot: out of tune (sharp/flat) &middot; Grey dotted trace: no target</span>
         </div>
         <div id="pitch-graph-canvas"></div>
         <div id="last-note-readout" class="hidden" aria-live="polite">Sung: — | Expected: —</div>

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -111,9 +111,8 @@ function updatePitchReadout(): void {
   const beat = session.engine.currentBeat;
   const expected = expectedNoteAtBeat(beat, activePartNotes);
 
-  el.textContent = `Detected: ${sungLabel}`;
-
   if (!expected) {
+    el.textContent = `Detected: ${sungLabel} — No target note`;
     readout.classList.remove('in-tune', 'out-of-tune');
     readout.classList.add('no-target');
     readout.textContent = `Sung: ${sungLabel} | Expected: —`;
@@ -122,6 +121,9 @@ function updatePitchReadout(): void {
 
   const centsError = (lastPitchFrame.midi - expected.midi) * 100;
   const inTune = Math.abs(centsError) <= GREEN_CENTS_THRESHOLD;
+  const accuracyLabel = inTune ? 'In tune' : centsError > 0 ? 'Sharp' : 'Flat';
+
+  el.textContent = `Detected: ${sungLabel} — ${accuracyLabel}`;
   readout.classList.toggle('in-tune', inTune);
   readout.classList.toggle('out-of-tune', !inTune);
   readout.classList.remove('no-target');

--- a/frontend/src/pitch/graph.test.ts
+++ b/frontend/src/pitch/graph.test.ts
@@ -8,6 +8,7 @@ import {
   pruneSamples,
   targetBandY,
   timeToGraphX,
+  traceLineDash,
 } from './graph';
 import { classifyGraphTraceColor, centsError, GRAPH_IN_TUNE_CENTS } from './graph-colors';
 
@@ -98,5 +99,14 @@ describe('targetBandY', () => {
     const pixelsPerSemitone = height / (GRAPH_MIDI_MAX - GRAPH_MIDI_MIN);
     const expectedHeightPx = (2 * cents / 100) * pixelsPerSemitone;
     expect(bandHeightPx).toBeCloseTo(expectedHeightPx, 1);
+  });
+});
+
+
+describe('traceLineDash', () => {
+  it('uses solid, dashed, and dotted line styles for accessibility', () => {
+    expect(traceLineDash('green')).toEqual([]);
+    expect(traceLineDash('red')).toEqual([7, 4]);
+    expect(traceLineDash('grey')).toEqual([2, 4]);
   });
 });

--- a/frontend/src/pitch/graph.ts
+++ b/frontend/src/pitch/graph.ts
@@ -96,6 +96,12 @@ export function targetBandY(
   return { topY, bottomY };
 }
 
+export function traceLineDash(color: GraphTraceColor): number[] {
+  if (color === 'red') return [7, 4];
+  if (color === 'grey') return [2, 4];
+  return [];
+}
+
 export class PitchGraphCanvas {
   private readonly canvas: HTMLCanvasElement;
   private readonly ctx: CanvasRenderingContext2D;
@@ -347,17 +353,20 @@ export class PitchGraphCanvas {
       const y2 = midiToGraphY(next.midi, height, this.viewRangeMinMidi, this.viewRangeMaxMidi);
 
       this.ctx.strokeStyle = this.cssColor(next.color);
+      this.ctx.setLineDash(traceLineDash(next.color));
       this.ctx.beginPath();
       this.ctx.moveTo(x1, y1);
       this.ctx.lineTo(x2, y2);
       this.ctx.stroke();
     }
+
+    this.ctx.setLineDash([]);
   }
 
   private cssColor(color: GraphTraceColor): string {
-    if (color === 'green') return '#4caf50';
-    if (color === 'red') return '#ef5350';
-    return '#9e9e9e';
+    if (color === 'green') return '#39d98a';
+    if (color === 'red') return '#ff9f1c';
+    return '#9aa4b2';
   }
 
   private resize = (): void => {


### PR DESCRIPTION
### Motivation

- Improve WCAG 1.4.1 compliance by ensuring pitch accuracy feedback is not conveyed by colour alone. 
- Provide a secondary visual encoding for sighted colour-blind users and semantic labels for screen-reader users via the existing `aria-live` region.

### Description

- Update pitch readout text in `updatePitchReadout()` to include semantic accuracy labels (`In tune`, `Sharp`, `Flat`, `No target note`) alongside the detected note so the existing `aria-live` element announces the full status. 
- Add `traceLineDash()` and apply `CanvasRenderingContext2D.setLineDash()` in `drawTrace()` to render solid/dashed/dotted trace styles for in-tune / out-of-tune / no-target states, and reset the dash after drawing. 
- Adjust graph colours to a green/orange/grey palette (`#39d98a`, `#ff9f1c`, `#9aa4b2`) and update the UI legend text in `index.html` to describe the combined colour + pattern encoding. 
- Add unit test coverage for the new `traceLineDash` helper in `frontend/src/pitch/graph.test.ts`.

### Testing

- Ran linter: `uv run ruff check backend/ --fix` and `uv run ruff check backend/` both passed. 
- Backend tests: `uv run pytest -v` failed to collect due to missing system libs (`PortAudio`) and missing `torch` in this environment, causing collection errors unrelated to these frontend changes. 
- Frontend unit tests: `cd frontend && npx vitest run src/pitch/graph.test.ts` passed (graph helper tests including `traceLineDash`), while `cd frontend && npm test` showed pre-existing unrelated failures and a TypeScript parse error in `src/playback/engine.ts` that prevented a fully green frontend test run. 
- I verified the trace drawing changes by running the updated `graph` tests and confirmed no regressions in the graph helper suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6907467dc8327a05998736f10bea6)

Closes #149