### PR TITLE
fix: settings panel a11y semantics and focus restoration

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -628,7 +628,15 @@
       <button id="btn-browse"   class="transport-btn">Browse…</button>
       <button id="btn-load-test-score" class="transport-btn" style="display:none;">Load test score</button>
       <button id="btn-diagnostics" class="transport-btn">Pitch diagnostics</button>
-      <button id="btn-settings" class="transport-btn">⚙ Settings</button>
+      <button
+        id="btn-settings"
+        class="transport-btn"
+        aria-haspopup="dialog"
+        aria-expanded="false"
+        aria-controls="settings-panel"
+      >
+        ⚙ Settings
+      </button>
 
       <span id="pitch-readout" aria-live="polite">Detected: —</span>
 
@@ -650,7 +658,7 @@
     </div>
 
     <!-- Settings panel (floats over content) -->
-    <aside id="settings-panel" aria-label="Settings panel">
+    <aside id="settings-panel" role="dialog" aria-modal="false" aria-labelledby="settings-panel-title">
       <div id="settings-panel-header">
         <h2 id="settings-panel-title">Settings</h2>
         <button id="btn-settings-close" class="transport-btn" aria-label="Close settings">&times;</button>

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -604,22 +604,38 @@ function mount(_slot: HTMLElement): void {
   refreshRecordingControls(ctrl);
   updateWarmupUi('Warm-up idle.');
 
+  async function openSettingsPanel(): Promise<void> {
+    settingsPanelEl.classList.add('visible');
+    btnSettings.setAttribute('aria-expanded', 'true');
+    await refreshAudioSettings(settingsDeviceEl, settingsEngineEl);
+  }
+
+  function closeSettingsPanel(): void {
+    if (!settingsPanelEl.classList.contains('visible')) return;
+    settingsPanelEl.classList.remove('visible');
+    btnSettings.setAttribute('aria-expanded', 'false');
+    btnSettings.focus();
+  }
+
   btnSettings.addEventListener('click', async (event) => {
     event.stopPropagation();
-    const visible = settingsPanelEl.classList.toggle('visible');
-    if (visible) await refreshAudioSettings(settingsDeviceEl, settingsEngineEl);
+    if (settingsPanelEl.classList.contains('visible')) {
+      closeSettingsPanel();
+      return;
+    }
+    await openSettingsPanel();
   });
-  btnSettingsClose.addEventListener('click', () => { settingsPanelEl.classList.remove('visible'); });
+  btnSettingsClose.addEventListener('click', () => { closeSettingsPanel(); });
   settingsPanelEl.addEventListener('click', (e) => { e.stopPropagation(); });
   window.addEventListener('click', (e) => {
     if (!settingsPanelEl.classList.contains('visible')) return;
     const target = e.target;
     if (!(target instanceof Node)) return;
     if (settingsPanelEl.contains(target) || btnSettings.contains(target)) return;
-    settingsPanelEl.classList.remove('visible');
+    closeSettingsPanel();
   });
   window.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape') settingsPanelEl.classList.remove('visible');
+    if (e.key === 'Escape') closeSettingsPanel();
   });
   settingsDeviceEl.addEventListener('change', () => {
     const v = settingsDeviceEl.value;


### PR DESCRIPTION
### Motivation
- Provide proper ARIA semantics so assistive technologies can discover the Settings panel and its state. 
- Ensure keyboard users don't lose their place by restoring focus to the trigger when the panel closes.

### Description
- Add `aria-haspopup=

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6906a3a2c83278904128de699558f)

Closes #148 