### PR TITLE
fix: document Space play/pause shortcut in transport UI

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -572,8 +572,8 @@
 
     <!-- Left toolbar: transport + part/tempo/transpose controls -->
     <div id="toolbar">
-      <button id="btn-play"   class="transport-btn">&#9654; Play</button>
-      <button id="btn-pause"  class="transport-btn">&#9646;&#9646; Pause</button>
+      <button id="btn-play"   class="transport-btn" title="Play (Space)" aria-keyshortcuts="Space">&#9654; Play (Space)</button>
+      <button id="btn-pause"  class="transport-btn" title="Pause or resume (Space)" aria-keyshortcuts="Space">&#9646;&#9646; Pause (Space)</button>
       <button id="btn-stop"   class="transport-btn">&#9646; Stop</button>
       <button id="btn-rewind" class="transport-btn">&#9664;&#9664; Rewind</button>
 

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -272,21 +272,21 @@ function mount(_slot: HTMLElement): void {
     // Pause/Resume: enabled when playing or paused.
     if (!session) {
       btnPause.disabled = true;
-      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
       return;
     }
     if (session.engine.state === 'playing') {
       btnPause.disabled = false;
-      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
       return;
     }
     if (session.engine.state === 'paused') {
       btnPause.disabled = false;
-      btnPause.innerHTML = '&#9654; Resume';
+      btnPause.innerHTML = '&#9654; Resume (Space)';
       return;
     }
     btnPause.disabled = true;
-    btnPause.innerHTML = '&#9646;&#9646; Pause';
+    btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
   }
 
   const unsubscribeLoaded = onScoreLoaded((session) => {
@@ -305,17 +305,17 @@ function mount(_slot: HTMLElement): void {
     const session = getSession();
     if (!session || session.engine.state === 'idle') {
       btnPause.disabled = true;
-      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
       return;
     }
     if (session.engine.state === 'playing') {
       btnPause.disabled = false;
-      btnPause.innerHTML = '&#9646;&#9646; Pause';
+      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
       return;
     }
     if (session.engine.state === 'paused') {
       btnPause.disabled = false;
-      btnPause.innerHTML = '&#9654; Resume';
+      btnPause.innerHTML = '&#9654; Resume (Space)';
     }
   }
 


### PR DESCRIPTION
### Motivation

- The Space key already toggles play/pause during playback but the shortcut was not discoverable in the UI or exposed to assistive tech.

### Description

- Add visible shortcut hint and accessibility metadata to the toolbar by updating the Play/Pause buttons in `frontend/index.html` to include `title` and `aria-keyshortcuts="Space"` and show `(Space)` in the label.
- Keep the hint consistent across runtime states by updating `frontend/src/features/playback/index.ts` so `btnPause.innerHTML` includes `(Space)` for Pause, Resume and idle states.
- This change is targeted at making the shortcut discoverable and improves keyboard/ARIA support for the transport controls and closes issue `#182`.

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both completed successfully.
- Ran `uv run pytest -v`, which failed to collect tests in this environment due to missing system dependencies (`PortAudio`) and missing `torch` resulting in collection errors.
- Ran frontend unit tests with `cd frontend && npm test` (Vitest), which executed the suite but reported 3 failing tests in unrelated files (`src/services/progress-history.test.ts` and `src/pitch/timeline-sync.test.ts`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6fa29908327a679cc33f7803cde)

Closes #182 