### PR TITLE
fix: render synthetic pitch trace using synced frame timestamps

### DIFF
--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -380,7 +380,10 @@ function startPitchGraphLoop(): void {
       const elapsedSec = session?.engine.playing
         ? Math.max(0, session.engine.ctx.currentTime - session.engine.startAudioTime)
         : warmupElapsedMs / 1000;
-      handleIncomingPitchFrame(syntheticPitchFrameAt(elapsedSec, expectedMidiForFrame(elapsedSec * 1000)));
+      const frameMs = session?.engine.playing
+        ? (timelineSync.audioToFrameTime(session.engine.ctx.currentTime) ?? (elapsedSec * 1000))
+        : (elapsedSec * 1000);
+      handleIncomingPitchFrame(syntheticPitchFrameAt(elapsedSec, expectedMidiForFrame(frameMs), frameMs));
     }
     if (session?.engine.playing) {
       const playbackSec = Math.max(0, session.engine.ctx.currentTime - session.engine.startAudioTime);

--- a/frontend/src/pitch/synthetic.test.ts
+++ b/frontend/src/pitch/synthetic.test.ts
@@ -15,6 +15,12 @@ describe('syntheticPitchFrameAt', () => {
     expect(frame.conf).toBe(0.95);
   });
 
+
+  it('uses explicit frame timestamp when provided', () => {
+    const frame = syntheticPitchFrameAt(4.2, 62, 9876);
+    expect(frame.t).toBe(9876);
+  });
+
   it('falls back to sweep when no expected midi exists', () => {
     const frame = syntheticPitchFrameAt(7, null);
     expect(frame.midi).toBeGreaterThan(48);

--- a/frontend/src/pitch/synthetic.ts
+++ b/frontend/src/pitch/synthetic.ts
@@ -3,7 +3,7 @@ import type { PitchFrame } from './socket';
 const SWEEP_MIN_MIDI = 48;
 const SWEEP_MAX_MIDI = 72;
 
-export function syntheticPitchFrameAt(nowSec: number, expectedMidi: number | null): PitchFrame {
+export function syntheticPitchFrameAt(nowSec: number, expectedMidi: number | null, tMs = nowSec * 1000): PitchFrame {
   const sweepMid = (SWEEP_MIN_MIDI + SWEEP_MAX_MIDI) / 2;
   const sweepAmp = (SWEEP_MAX_MIDI - SWEEP_MIN_MIDI) / 2;
   const sweepMidi = sweepMid + (Math.sin(nowSec * 0.55) * sweepAmp);
@@ -14,7 +14,7 @@ export function syntheticPitchFrameAt(nowSec: number, expectedMidi: number | nul
   const wobble = Math.sin(nowSec * 7.3) * 0.03;
 
   return {
-    t: nowSec * 1000,
+    t: tMs,
     midi: baseMidi + offset + wobble,
     conf: 0.95,
   };


### PR DESCRIPTION
### Motivation
- Synthetic pitch mode produced no visible trace because generated frames used local elapsed timestamps instead of the playback-synced frame timeline and were treated as stale and dropped. 
- The change aligns synthetic frames with the same frame timeline used for backend WebSocket frames so the overlay pipeline can position and render them reliably.

### Description
- Update `syntheticPitchFrameAt` to accept an optional explicit `tMs` timestamp so synthetic frames can carry a playback-synced frame time (`frontend/src/pitch/synthetic.ts`).
- When injecting synthetic frames in the RAF loop, derive `frameMs` from `timelineSync.audioToFrameTime(session.engine.ctx.currentTime)` with an `elapsedSec*1000` fallback during warmup, and pass it into the generator (`frontend/src/features/pitch-overlay/index.ts`).
- Add a unit test verifying the explicit timestamp override is propagated (`frontend/src/pitch/synthetic.test.ts`).
- Files changed: `frontend/src/features/pitch-overlay/index.ts`, `frontend/src/pitch/synthetic.ts`, `frontend/src/pitch/synthetic.test.ts` (Closes #183).

### Testing
- `uv run ruff check backend/ --fix` completed successfully. 
- `uv run ruff check backend/` completed successfully. 
- `npm --prefix frontend test -- synthetic.test.ts` ran the frontend unit tests and the synthetic tests passed. 
- `uv run pytest -v` could not complete in this environment due to missing system dependencies (`PortAudio` runtime) and `torch` during collection, causing test collection to fail.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6f06cb48327936acdd904473981)

Closes #183 