### PR TITLE
fix(pitch-graph): add a11y role and descriptive aria-label to canvas

### DIFF
--- a/frontend/src/pitch/graph.test.ts
+++ b/frontend/src/pitch/graph.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildPitchGraphAriaLabel,
   buildSemitoneGrid,
   DEFAULT_BAND_CENTS_TOLERANCE,
   GRAPH_MIDI_MAX,
@@ -12,6 +13,15 @@ import {
 } from './graph';
 import { classifyGraphTraceColor, centsError, GRAPH_IN_TUNE_CENTS } from './graph-colors';
 
+
+
+describe('pitch graph accessibility label', () => {
+  it('describes note range and rolling time window', () => {
+    expect(buildPitchGraphAriaLabel(36, 84, 10)).toBe(
+      'Real-time pitch graph showing your sung pitch (C2–C6) over a 10-second rolling window',
+    );
+  });
+});
 describe('graph coordinate helpers', () => {
   it('maps midi bounds to canvas bounds', () => {
     expect(midiToGraphY(GRAPH_MIDI_MAX, 100)).toBe(0);

--- a/frontend/src/pitch/graph.ts
+++ b/frontend/src/pitch/graph.ts
@@ -37,6 +37,17 @@ interface GridLine {
 const NOTE_NAMES = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
 const KEYBOARD_GUTTER_PX = 56;
 
+function midiToNoteName(midi: number): string {
+  const rounded = Math.round(midi);
+  const note = NOTE_NAMES[((rounded % 12) + 12) % 12] ?? 'C';
+  const octave = Math.floor(rounded / 12) - 1;
+  return `${note}${octave}`;
+}
+
+export function buildPitchGraphAriaLabel(minMidi: number, maxMidi: number, windowSeconds: number): string {
+  return `Real-time pitch graph showing your sung pitch (${midiToNoteName(minMidi)}–${midiToNoteName(maxMidi)}) over a ${windowSeconds}-second rolling window`;
+}
+
 function midiToScaleLabel(midi: number): string | null {
   const note = NOTE_NAMES[midi % 12];
   if (note.includes('#')) return null;
@@ -119,6 +130,9 @@ export class PitchGraphCanvas {
       bandCentsTolerance: opts.bandCentsTolerance ?? DEFAULT_BAND_CENTS_TOLERANCE,
     };
     this.canvas = document.createElement('canvas');
+    this.canvas.setAttribute('role', 'img');
+    this.canvas.setAttribute('aria-label', buildPitchGraphAriaLabel(this.fullRangeMinMidi, this.fullRangeMaxMidi, this.opts.windowSeconds));
+    this.canvas.textContent = 'Real-time pitch graph';
     this.canvas.style.width = '100%';
     this.canvas.style.height = '100%';
 
@@ -148,6 +162,7 @@ export class PitchGraphCanvas {
 
   setWindowSeconds(sec: number): void {
     this.opts.windowSeconds = Math.max(2, Math.min(30, sec));
+    this.updateAriaLabel();
   }
 
   setBandCentsTolerance(cents: number): void {
@@ -164,12 +179,18 @@ export class PitchGraphCanvas {
     this.fullRangeMinMidi = minMidi;
     this.fullRangeMaxMidi = maxMidi;
     this.resetViewport();
+    this.updateAriaLabel();
   }
 
   resetRange(): void {
     this.fullRangeMinMidi = GRAPH_MIDI_MIN;
     this.fullRangeMaxMidi = GRAPH_MIDI_MAX;
     this.resetViewport();
+    this.updateAriaLabel();
+  }
+
+  private updateAriaLabel(): void {
+    this.canvas.setAttribute('aria-label', buildPitchGraphAriaLabel(this.fullRangeMinMidi, this.fullRangeMaxMidi, this.opts.windowSeconds));
   }
 
   autoCenterOnMidi(expectedMidi: number | null): void {


### PR DESCRIPTION
### Motivation

- The runtime-created pitch graph `<canvas>` had no `role` or `aria-label`, making it inaccessible to screen readers and failing WCAG non-text content requirements.

### Description

- Add `role="img"`, a descriptive `aria-label` built by `buildPitchGraphAriaLabel(...)`, and fallback text (`Real-time pitch graph`) to the pitch graph canvas created in `frontend/src/pitch/graph.ts`.
- Add `midiToNoteName(...)` and `buildPitchGraphAriaLabel(...)` helpers to generate consistent human-readable labels describing the note range and rolling window duration.
- Keep the aria label in sync by calling `updateAriaLabel()` from `setWindowSeconds`, `setRange`, and `resetRange` so changes to range or window update the label.
- Add a unit test `describe('pitch graph accessibility label', ...)` in `frontend/src/pitch/graph.test.ts` to validate the generated aria-label text.

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded.
- Ran frontend unit tests with `npm test -- src/pitch/graph.test.ts` from the `frontend/` directory and the file-level tests passed (`src/pitch/graph.test.ts` — 13 tests passed).
- Ran `uv run pytest -v`; test collection failed in this environment due to missing system/library dependencies (PortAudio not available to `sounddevice` and `torch` not installed), so backend test run did not complete here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6e84dc08327aa399eb90d664e0d)

Closes #180 