### PR TITLE
fix: add missing progress history slot to frontend layout

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -772,6 +772,7 @@
       <div id="slot-part-selector" class="feature-slot"></div>
       <div id="slot-pitch-overlay" class="feature-slot"></div>
       <div id="slot-audio-preflight" class="feature-slot"></div>
+      <div id="slot-progress-history" class="feature-slot"></div>
     </div>
 
   </div>


### PR DESCRIPTION
### Motivation
- Prevent a startup console warning by ensuring the DOM contains the mount anchor that `progressHistoryFeature.id` expects so the registry can mount the feature without logging a missing-slot warning.

### Description
- Add `<div id="slot-progress-history" class="feature-slot"></div>` to `frontend/index.html` in the feature mount slots area so it matches `progressHistoryFeature.id` and allows the feature to mount cleanly.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which both passed successfully; `uv run pytest -v` was executed but collection failed due to missing system deps (`PortAudio`) and `torch` in this environment so tests could not be completed; `npm --prefix frontend test` was run and reported pre-existing frontend test failures unrelated to this HTML slot addition (3 failing tests).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6da771c8327938a287633a8dc99)

Closes #181 