### PR TITLE
fix: disable stop/rewind controls in stopped state

### DIFF
--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -261,13 +261,19 @@ function mount(_slot: HTMLElement): void {
 
   function syncTransportButtons(): void {
     const session = getSession();
+    const playbackState = session?.engine.state ?? 'idle';
+    const canTransport = playbackState === 'playing' || playbackState === 'paused';
 
     // Play: enabled only when a score is loaded and not already playing.
-    if (!session || session.engine.state === 'playing') {
+    if (!session || playbackState === 'playing') {
       btnPlay.disabled = true;
     } else {
       btnPlay.disabled = false;
     }
+
+    // Stop/Rewind: enabled only while transport is active (playing/paused).
+    btnStop.disabled = !canTransport;
+    btnRewind.disabled = !canTransport;
 
     // Pause/Resume: enabled when playing or paused.
     if (!session) {
@@ -275,12 +281,12 @@ function mount(_slot: HTMLElement): void {
       btnPause.innerHTML = '&#9646;&#9646; Pause';
       return;
     }
-    if (session.engine.state === 'playing') {
+    if (playbackState === 'playing') {
       btnPause.disabled = false;
       btnPause.innerHTML = '&#9646;&#9646; Pause';
       return;
     }
-    if (session.engine.state === 'paused') {
+    if (playbackState === 'paused') {
       btnPause.disabled = false;
       btnPause.innerHTML = '&#9654; Resume';
       return;


### PR DESCRIPTION
### Motivation
- Stop and Rewind remained enabled when playback was in the stopped/idle state, causing confusing UI actions (e.g. reopening the Practice Summary or re-rendering the score) and inconsistent transport state.

### Description
- Normalize the playback state once into `playbackState` and compute `canTransport` in `frontend/src/features/playback/index.ts` and use that to drive button states.
- Disable `btnStop` and `btnRewind` when `canTransport` is false (i.e. unless `playbackState` is `playing` or `paused`), while preserving existing Play/Pause logic.
- Minor refactor to reuse the normalized playback-state variable for Play/Pause conditionals (no behavior change beyond Stop/Rewind disabling). Closes #178

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded.
- Ran `uv run pytest -v`, which failed during collection in this environment due to missing system dependencies (`PortAudio`) and missing `torch` (environment limitation, not caused by this change).
- Ran `npm --prefix frontend test`, where the frontend test suite ran and most tests passed but 3 existing frontend tests failed (`src/services/progress-history.test.ts` and `src/pitch/timeline-sync.test.ts`) which are unrelated to this change.
- Started the dev server and captured a Playwright screenshot to validate the transport UI state visually (smoke validation).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6a6d270e483278cef5ceaede7769c)

Closes #178 