### PR TITLE
refactor: return unsubscribe functions from score session listeners

### DIFF
--- a/frontend/src/features/part-selector/index.ts
+++ b/frontend/src/features/part-selector/index.ts
@@ -15,6 +15,9 @@ import { getVisiblePartOptions } from '../../part-options';
 import { setPlaybackTempo, setPlaybackTranspose } from '../../transport/controls';
 import { type Feature } from '../../feature-types';
 
+let unsubscribeScoreLoaded: (() => void) | null = null;
+let unsubscribeScoreCleared: (() => void) | null = null;
+
 function mount(_slot: HTMLElement): void {
   const partSelectEl      = document.getElementById('part-select')        as HTMLSelectElement;
   const showAccompEl      = document.getElementById('show-accompaniment') as HTMLInputElement;
@@ -63,8 +66,10 @@ function mount(_slot: HTMLElement): void {
     if (session.selectedPart !== selectedPart) updateSelectedPart(selectedPart);
   }
 
-  onScoreCleared(() => { partSelectEl.innerHTML = ''; });
-  onScoreLoaded(() => { refreshPartSelector(); });
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreLoaded?.();
+  unsubscribeScoreCleared = onScoreCleared(() => { partSelectEl.innerHTML = ''; });
+  unsubscribeScoreLoaded = onScoreLoaded(() => { refreshPartSelector(); });
 
   partSelectEl.addEventListener('change', () => {
     scheduleSelectedPart(partSelectEl.value);
@@ -112,7 +117,12 @@ function mount(_slot: HTMLElement): void {
   });
 }
 
-function unmount(): void { /* stateless */ }
+function unmount(): void {
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreCleared = null;
+  unsubscribeScoreLoaded?.();
+  unsubscribeScoreLoaded = null;
+}
 
 export const partSelectorFeature: Feature = {
   id: 'slot-part-selector',

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -61,6 +61,8 @@ let wasPlayingLastTick = false;
 const sessionRangeTracker = new SessionRangeTracker();
 const timelineSync = new PitchTimelineSync();
 let playbackSyncUnsubscribe: (() => void) | null = null;
+let unsubscribeScoreLoaded: (() => void) | null = null;
+let unsubscribeScoreCleared: (() => void) | null = null;
 let syncOffsetWarningShown = false;
 
 let warmupActive = false;
@@ -436,7 +438,10 @@ function mount(_slot: HTMLElement): void {
   startPitchGraphLoop();
   clearPhraseSummaryPanel();
 
-  onScoreCleared(() => {
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreLoaded?.();
+
+  unsubscribeScoreCleared = onScoreCleared(() => {
     closePitchSocket();
     finalizeSessionRangeSummary();
     pitchOverlay?.destroy();
@@ -453,7 +458,7 @@ function mount(_slot: HTMLElement): void {
     updateSessionRangeReadout();
   });
 
-  onScoreLoaded((session) => {
+  unsubscribeScoreLoaded = onScoreLoaded((session) => {
     pitchOverlay?.destroy();
     pitchOverlay = new PitchOverlay(
       scoreContainerEl, session.model, session.selectedPart, overlaySettings);
@@ -591,6 +596,10 @@ function mount(_slot: HTMLElement): void {
 function unmount(): void {
   playbackSyncUnsubscribe?.();
   playbackSyncUnsubscribe = null;
+  unsubscribeScoreLoaded?.();
+  unsubscribeScoreLoaded = null;
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreCleared = null;
   closePitchSocket();
   stopPitchGraphLoop();
   pitchOverlay?.destroy(); pitchOverlay = null;

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -28,6 +28,8 @@ import { ensureAudioPreflightReady } from '../../services/audio-preflight';
 // ── Cursor RAF ──────────────────────────────────────────────────────────────────
 
 let cursorRafId: number | null = null;
+let unsubscribeScoreLoaded: (() => void) | null = null;
+let unsubscribeScoreCleared: (() => void) | null = null;
 
 function startCursorRaf(): void {
   stopCursorRaf();
@@ -134,9 +136,6 @@ function mount(_slot: HTMLElement): void {
   const summaryRetry     = document.getElementById('btn-summary-retry')  as HTMLButtonElement;
   const summaryReplay    = document.getElementById('btn-summary-replay') as HTMLButtonElement;
 
-  // Merge into a single onScoreCleared callback so both always fire together,
-  // regardless of whether the implementation replaces or appends listeners.
-  onScoreCleared(() => { stopCursorRaf(); finishPracticeSessionCapture(); });
 
   function syncTransportButtons(): void {
     const session = getSession();
@@ -186,8 +185,14 @@ function mount(_slot: HTMLElement): void {
     }
   }
 
-  onScoreLoaded(() => { syncTransportButtons(); });
-  onScoreCleared(() => { stopCursorRaf(); syncTransportButtons(); });
+  unsubscribeScoreLoaded?.();
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreLoaded = onScoreLoaded(() => { syncTransportButtons(); });
+  unsubscribeScoreCleared = onScoreCleared(() => {
+    stopCursorRaf();
+    finishPracticeSessionCapture();
+    syncTransportButtons();
+  });
 
   btnPlay.addEventListener('click', async () => {
     const session = getSession();
@@ -365,6 +370,10 @@ function mount(_slot: HTMLElement): void {
 
 function unmount(): void {
   stopCursorRaf();
+  unsubscribeScoreLoaded?.();
+  unsubscribeScoreLoaded = null;
+  unsubscribeScoreCleared?.();
+  unsubscribeScoreCleared = null;
 }
 
 export const playbackFeature: Feature = {

--- a/frontend/src/services/score-session.test.ts
+++ b/frontend/src/services/score-session.test.ts
@@ -56,4 +56,42 @@ describe('score-session store', () => {
 
     expect(onPartChanged).not.toHaveBeenCalled();
   });
+  it('supports unsubscribing score-loaded and score-cleared listeners', async () => {
+    const store = await import('./score-session');
+    const onLoaded = vi.fn();
+    const onCleared = vi.fn();
+
+    const unsubscribeLoaded = store.onScoreLoaded(onLoaded);
+    const unsubscribeCleared = store.onScoreCleared(onCleared);
+
+    store.setSession(buildSession('Soprano'));
+    store.clearSession();
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(onCleared).toHaveBeenCalledTimes(1);
+
+    unsubscribeLoaded();
+    unsubscribeCleared();
+
+    store.setSession(buildSession('Alto'));
+    store.clearSession();
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(onCleared).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires score-loaded callback immediately when subscribing with an active session', async () => {
+    const store = await import('./score-session');
+    const existing = buildSession('Soprano');
+    store.setSession(existing);
+
+    const onLoaded = vi.fn();
+    const unsubscribe = store.onScoreLoaded(onLoaded);
+
+    expect(onLoaded).toHaveBeenCalledTimes(1);
+    expect(onLoaded).toHaveBeenCalledWith(existing);
+
+    unsubscribe();
+  });
+
 });

--- a/frontend/src/services/score-session.ts
+++ b/frontend/src/services/score-session.ts
@@ -63,9 +63,13 @@ export function getSession(): ScoreSession | null {
  * If a session already exists at registration time the callback fires
  * immediately — useful for features that mount after a score has loaded.
  */
-export function onScoreLoaded(cb: SessionCallback): void {
+export function onScoreLoaded(cb: SessionCallback): () => void {
   loadedCallbacks.push(cb);
   if (current) cb(current);
+  return () => {
+    const idx = loadedCallbacks.indexOf(cb);
+    if (idx !== -1) loadedCallbacks.splice(idx, 1);
+  };
 }
 
 /**
@@ -79,8 +83,12 @@ export function onPartChanged(cb: SessionCallback): void {
 }
 
 /** Register a callback fired just before each session tear-down. */
-export function onScoreCleared(cb: ClearCallback): void {
+export function onScoreCleared(cb: ClearCallback): () => void {
   clearCallbacks.push(cb);
+  return () => {
+    const idx = clearCallbacks.indexOf(cb);
+    if (idx !== -1) clearCallbacks.splice(idx, 1);
+  };
 }
 
 /**


### PR DESCRIPTION
### Motivation

- Prevent listener accumulation when features mount multiple times by allowing `onScoreLoaded` and `onScoreCleared` to return unsubscribe functions so features can deregister their callbacks.

### Description

- Changed `onScoreLoaded` and `onScoreCleared` in `frontend/src/services/score-session.ts` to return `() => void` unsubscribe functions that remove the registered callback from the internal arrays.
- Updated feature modules to store and call the unsubscribe functions during lifecycle transitions, specifically in `frontend/src/features/playback/index.ts`, `frontend/src/features/part-selector/index.ts`, and `frontend/src/features/pitch-overlay/index.ts` so `mount()` registers and `unmount()` cleans up listeners.
- Added unit tests in `frontend/src/services/score-session.test.ts` to cover unsubscribe behavior and immediate invocation when subscribing with an active session.

### Testing

- Ran the score-session unit tests with `npm --prefix frontend test -- src/services/score-session.test.ts` and they passed. ✅
- Ran the full frontend test suite with `npm --prefix frontend test`; the score-session tests passed but the overall test run failed due to pre-existing unrelated failures in other tests (`src/pitch/stable-note.test.ts` and `src/services/progress-history.test.ts`). ❌
- Attempted a frontend build with `npm --prefix frontend run build` which failed due to existing unrelated TypeScript issues in other modules; the changes in this PR do not introduce these breakages. ❌

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b677e54e9c8327a15be1dce553ab3f)