### PR TITLE
fix: make settings panel scrollable within viewport

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -309,6 +309,8 @@
       right: 20px;
       top: 64px;
       width: min(360px, calc(100vw - 40px));
+      max-height: calc(100vh - 84px);
+      overflow-y: auto;
       background: var(--color-border);
       border: 1px solid #1a5276;
       border-radius: 8px;


### PR DESCRIPTION
### Motivation
- The floating Settings panel was taller than some viewports and used `overflow-y: visible`, causing controls to be cut off and inaccessible on small/medium screens; the intent is to constrain the panel to the viewport and allow internal scrolling.

### Description
- Add `max-height: calc(100vh - 84px)` and `overflow-y: auto` to `#settings-panel` in `frontend/index.html` so the panel fits the visible window and scrolls internally; this resolves the overflow issue and closes `#175`.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded. 
- Ran `uv run pytest -v`, which failed during collection in this environment due to missing system/runtime deps (`PortAudio` and `torch`) unrelated to this CSS change. 
- Ran frontend unit tests with `npm --prefix frontend run test` (Vitest): most tests passed but there are 3 pre-existing failing frontend tests unrelated to this CSS-only change (`src/services/progress-history.test.ts` — 2 failures, and `src/pitch/timeline-sync.test.ts` — 1 failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1d3eccc8327b28da9d6f3298be8)

Closes #175 