### PR TITLE
fix: close Practice Summary and Audio Setup modals on Escape

### DIFF
--- a/frontend/src/features/audio-preflight/index.ts
+++ b/frontend/src/features/audio-preflight/index.ts
@@ -39,6 +39,7 @@ let voiceTypeSelectEl: HTMLSelectElement | null = null;
 let voiceTypeSuggestionEl: HTMLDivElement | null = null;
 let octaveCompCheckboxEl: HTMLInputElement | null = null;
 const METER_GAIN_SCALE = 140;
+let removeEscapeListener: (() => void) | null = null;
 
 let selectedDeviceId: string | null = loadPreflightDeviceId();
 let selectedVoiceTypeId: string | null = loadUserVoiceTypeId();
@@ -316,6 +317,17 @@ function ensureStyles(): void {
 async function openModal(): Promise<boolean> {
   if (!modalEl) return false;
   modalEl.classList.remove('hidden');
+  removeEscapeListener?.();
+  const onEscape = (event: KeyboardEvent): void => {
+    if (event.key !== 'Escape' || isPreflightModalHidden()) return;
+    event.preventDefault();
+    closeModal(false);
+  };
+  window.addEventListener('keydown', onEscape);
+  removeEscapeListener = () => {
+    window.removeEventListener('keydown', onEscape);
+    removeEscapeListener = null;
+  };
   await requestPermissionAndDevices();
   return new Promise<boolean>((resolve) => {
     resolver = resolve;
@@ -324,6 +336,7 @@ async function openModal(): Promise<boolean> {
 
 function closeModal(completed: boolean): void {
   if (modalEl) modalEl.classList.add('hidden');
+  removeEscapeListener?.();
   monitorGain && (monitorGain.gain.value = 0);
   isMonitoring = false;
   if (testButtonEl) testButtonEl.textContent = 'Test my mic';
@@ -403,6 +416,7 @@ function mount(_slot: HTMLElement): void {
 
 function unmount(): void {
   cleanupMonitor();
+  removeEscapeListener?.();
   // monitorCtx is already closed and nulled by cleanupMonitor()
   modalEl?.remove();
   modalEl = null;
@@ -411,7 +425,12 @@ function unmount(): void {
 
 export const __audioPreflightInternals = {
   resolveSelectedDeviceId,
+  isPreflightModalHidden,
 };
+
+function isPreflightModalHidden(): boolean {
+  return !modalEl || modalEl.classList.contains('hidden');
+}
 
 export const audioPreflightFeature: Feature = {
   id: 'slot-audio-preflight',

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -224,6 +224,11 @@ function hideSessionSummary(): void {
   modal?.classList.add('hidden');
 }
 
+function isSessionSummaryOpen(): boolean {
+  const modal = document.getElementById('session-summary-modal') as HTMLDivElement | null;
+  return Boolean(modal && !modal.classList.contains('hidden'));
+}
+
 // ── mount ─────────────────────────────────────────────────────────────────
 
 function mount(_slot: HTMLElement): void {
@@ -510,6 +515,12 @@ function mount(_slot: HTMLElement): void {
     const target = e.target as HTMLElement | null;
     const tag = target?.tagName;
     if (target?.isContentEditable || tag === 'INPUT' || tag === 'TEXTAREA' || tag === 'SELECT') return;
+
+    if (e.code === 'Escape' && isSessionSummaryOpen()) {
+      e.preventDefault();
+      hideSessionSummary();
+      return;
+    }
 
     const session = getSession();
     if (!session) return;


### PR DESCRIPTION
### Motivation

- Modal dialogs implemented as non-native elements did not close on `Escape`, which is a usability and accessibility problem (WCAG / expected UX). 
- The Practice Summary and Audio Setup modals must be dismissible with the `Escape` key to avoid keyboard traps and improve discoverability.

### Description

- In `frontend/src/features/playback/index.ts` added `isSessionSummaryOpen()` and short-circuited the global `keydown` handler so `Escape` closes the Practice Summary modal before falling back to transport/loop behavior. 
- In `frontend/src/features/audio-preflight/index.ts` registered a scoped `keydown` listener while the preflight modal is open so `Escape` dismisses the Audio Setup modal, and added `isPreflightModalHidden()` plus a `removeEscapeListener` lifecycle helper. 
- Ensured the preflight `Escape` listener is removed when the modal closes or the feature unmounts to avoid leaking handlers.

### Testing

- Ran linter checks with `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded. 
- Ran backend tests with `uv run pytest -v` which failed in this environment due to missing system deps (`PortAudio`) and `torch` which prevent collection. 
- Ran targeted frontend tests `npm run test -- src/features/audio-preflight/index.test.ts src/practice/session-summary.test.ts` and they passed. 
- Running the full frontend test suite (`npm test`) and `npm run build` surfaced unrelated pre-existing failures in other tests and TypeScript unused-symbol checks (not caused by these changes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1cb4fa08327bc35d6029c0bde60)

Closes #177 