### PR TITLE
fix: normalize compact roman numeral part labels

### DIFF
--- a/backend/score/parser.py
+++ b/backend/score/parser.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import zipfile
 import xml.etree.ElementTree as ET
+import re
 from pathlib import Path
 
 from music21 import converter, meter, tempo as m21tempo
@@ -156,7 +157,7 @@ def _extract_parts(score: Score) -> tuple[list[Note], list[str]]:
     seen_names: set[str] = set()
 
     for part in score.parts:
-        raw_name = part.partName or "Unknown"
+        raw_name = _normalize_part_name(part.partName or "Unknown")
         # Deduplicate grand-staff piano (appears as two parts with same name)
         if raw_name in seen_names:
             continue
@@ -176,6 +177,12 @@ def _extract_parts(score: Score) -> tuple[list[Note], list[str]]:
     # Sort by beat position for predictable consumption
     all_notes.sort(key=lambda n: (n.beat_start, n.part))
     return all_notes, part_names
+
+
+def _normalize_part_name(name: str) -> str:
+    """Normalise common compact vocal labels like ``PARTI`` to ``PART I``."""
+    normalized = name.strip()
+    return re.sub(r"^(PART)\s*([IVX]+)$", r"\1 \2", normalized, flags=re.IGNORECASE)
 
 
 def _make_note(

--- a/backend/tests/test_score.py
+++ b/backend/tests/test_score.py
@@ -13,7 +13,7 @@ from pathlib import Path
 import pytest
 from music21 import bar, meter, note, stream
 
-from backend.score.parser import _expand_repeats, parse_musicxml
+from backend.score.parser import _expand_repeats, _normalize_part_name, parse_musicxml
 from backend.score.model import ScoreModel
 from backend.score.timeline import Timeline
 
@@ -21,6 +21,18 @@ SCORES_DIR = Path(__file__).parent.parent.parent / "musescore"
 FULL_SCORE   = SCORES_DIR / "homeward_bound.mxl"
 PART_I       = SCORES_DIR / "homeward_bound-PARTI.mxl"
 PART_II      = SCORES_DIR / "homeward_bound-PART_II.mxl"
+
+
+class TestPartNameNormalisation:
+
+    def test_inserts_space_for_compact_roman_numerals(self):
+        assert _normalize_part_name("PARTI") == "PART I"
+
+    def test_preserves_existing_whitespace(self):
+        assert _normalize_part_name("PART II") == "PART II"
+
+    def test_leaves_non_part_names_unchanged(self):
+        assert _normalize_part_name("PIANO") == "PIANO"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
### Motivation

- The part selector displayed compact labels like `PARTI` without a space, causing a UI display bug for some MusicXML inputs.
- Normalising parsed part names prevents inconsistent formatting and ensures dropdowns show `PART I`, `PART II`, etc.

### Description

- Add `_normalize_part_name` to `backend/score/parser.py` which uses a regex to convert compact labels like `PARTI` into `PART I` while preserving existing whitespace and non-`PART` names. 
- Apply `_normalize_part_name` when extracting `part.partName` so both the `parts` list and note `part` fields use the normalised value.
- Add unit tests in `backend/tests/test_score.py` covering `PARTI` → `PART I`, preserving `PART II`, and leaving `PIANO` unchanged.
- Run `ruff` fixes and formatting on the backend sources.

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which both passed. 
- Ran `uv run pytest backend/tests/test_score.py -v` which passed (parser-related tests: 22 passed, 19 skipped, 2 warnings). 
- Ran `uv run pytest -v` in this environment which failed during collection due to missing system/library dependencies (PortAudio) and missing `torch`, unrelated to the parser changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1c2f8048327be45d8269741d7d2)

Closes #176 