### PR TITLE
fix: resolve persistent score loading overlay after render

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -753,7 +753,7 @@
 
       <!-- Score / drop-zone area -->
       <main>
-        <div id="score-loading" aria-live="polite">Loading score…</div>
+        <div id="score-loading" aria-live="polite">No score loaded.</div>
         <div id="drop-zone">
           <p>Drop a MusicXML file here</p>
           <span>.xml or .mxl — or click to browse</span>

--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -13,6 +13,7 @@
 import { ScoreRenderer, type ScoreModel } from '../../score/renderer';
 import { ScoreCursor } from '../../score/cursor';
 import { PlaybackEngine } from '../../playback/engine';
+import './score-loader.css';
 import {
   getAudioContext,
   getSoundfont,
@@ -107,7 +108,7 @@ function mount(slot: HTMLElement): void {
   function resetDropZoneToIdle(): void {
     dropZoneEl.innerHTML = dropZoneIdleMarkup;
     dropZoneEl.classList.remove('hidden', 'drag-over');
-    scoreLoadingEl.textContent = 'Loading score…';
+    scoreLoadingEl.textContent = 'No score loaded.';
   }
 
   // ── Helpers ────────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- The loading overlay shows the text "Loading score…" on a fresh page load even when nothing is loading, which is misleading. 
- After a score finishes rendering the overlay text (e.g. "Loading homeward_bound.mxl…") remained visible because the element was not initialized/hidden to the idle state.

### Description
- Import the feature stylesheet from `frontend/src/features/score-loader/index.ts` so `#score-loading` obeys its CSS (hidden by default and shown only when `.visible` is added).
- Change the idle copy from `Loading score…` to `No score loaded.` in `frontend/index.html` and in `resetDropZoneToIdle()` so the initial state does not imply an active load.
- Preserve existing show/hide semantics: `showLoading()` still sets the message and adds the `visible` class, and `hideLoading()` removes the `visible` class after load attempts.

### Testing
- Ran lint/fix with `uv run ruff check backend/ --fix` which completed successfully.
- Ran `uv run ruff check backend/` which completed successfully.
- Ran backend tests with `uv run pytest -v` which failed to collect due to missing system deps in this environment (`PortAudio` and missing `torch`) and are unrelated to this change.
- Ran frontend unit tests with `npm --prefix frontend test`, which exercised the frontend test suite but reported pre-existing unrelated failures (some tests in `progress-history` and `timeline-sync`) and are unrelated to the loading overlay fix.
- Built and served the frontend during validation; snapshot screenshot of initial page confirms the neutral placeholder is shown instead of an active loading overlay.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1bb32b083279c9fcc854585f51b)

Closes #172 