### PR TITLE
fix: add stop/cancel control for warm-up sessions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,6 +35,7 @@
   Closes #8
   ```
 - `Closes #N` goes in the **body**, not the subject line
+- PR descriptions must also include `Closes #N` for the linked issue (e.g. `Closes #179`) so merge auto-closes it
 - Do not leave any commit without an issue reference — it makes history untraceable
 - Types: `feat`, `fix`, `test`, `chore`, `refactor`, `docs`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,7 @@
   Closes #8
   ```
 - `Closes #N` goes in the **body**, not the subject line
+- PR descriptions must also include `Closes #N` for the linked issue (e.g. `Closes #179`) so merge auto-closes it
 - Do not leave any commit without an issue reference — it makes history untraceable
 - Types: `feat`, `fix`, `test`, `chore`, `refactor`, `docs`
 

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -651,6 +651,7 @@
           <option value="180">3 min</option>
         </select>
         <button id="btn-start-warmup" class="transport-btn">🎵 Start warm-up</button>
+        <button id="btn-stop-warmup" class="transport-btn hidden">⏹ Stop warm-up</button>
         <button id="btn-start-rehearsal" class="transport-btn hidden">Start rehearsal</button>
         <span id="warmup-status" aria-live="polite">Warm-up idle.</span>
       </div>

--- a/frontend/src/features/pitch-overlay/index.ts
+++ b/frontend/src/features/pitch-overlay/index.ts
@@ -134,9 +134,17 @@ function updatePitchReadout(): void {
 function syncWarmupUi(message?: string): void {
   const warmupStatusEl = document.getElementById('warmup-status') as HTMLSpanElement | null;
   const btnStartWarmup = document.getElementById('btn-start-warmup') as HTMLButtonElement | null;
+  const btnStopWarmup = document.getElementById('btn-stop-warmup') as HTMLButtonElement | null;
   const btnStartRehearsal = document.getElementById('btn-start-rehearsal') as HTMLButtonElement | null;
   if (warmupStatusEl && message !== undefined) warmupStatusEl.textContent = message;
-  if (btnStartWarmup) btnStartWarmup.disabled = warmupActive;
+  if (btnStartWarmup) {
+    btnStartWarmup.disabled = warmupActive;
+    btnStartWarmup.classList.toggle('hidden', warmupActive);
+  }
+  if (btnStopWarmup) {
+    btnStopWarmup.disabled = !warmupActive;
+    btnStopWarmup.classList.toggle('hidden', !warmupActive);
+  }
   if (btnStartRehearsal) btnStartRehearsal.classList.toggle('hidden', warmupActive || warmupSequence.length === 0);
 }
 
@@ -482,6 +490,7 @@ function mount(_slot: HTMLElement): void {
   const scoreContainerEl    = document.getElementById('score-container')           as HTMLDivElement;
   const warmupDurationEl    = document.getElementById('warmup-duration')           as HTMLSelectElement;
   const btnStartWarmup      = document.getElementById('btn-start-warmup')          as HTMLButtonElement;
+  const btnStopWarmup       = document.getElementById('btn-stop-warmup')           as HTMLButtonElement;
   const btnStartRehearsal   = document.getElementById('btn-start-rehearsal')       as HTMLButtonElement;
   const pitchGraphCanvasEl  = document.getElementById('pitch-graph-canvas')        as HTMLDivElement;
   const settingsPanelEl     = document.getElementById('settings-panel')            as HTMLDivElement;
@@ -525,6 +534,13 @@ function mount(_slot: HTMLElement): void {
     warmupActive = true;
     updateWarmupUi('Warm-up in progress: sirens');
     connectPitchSocket();
+  }
+
+  function stopWarmup(): void {
+    if (!warmupActive) return;
+    warmupActive = false;
+    warmupTargetMidi = null;
+    updateWarmupUi('Warm-up stopped. You can start rehearsal.');
   }
 
   pitchGraph = new PitchGraphCanvas(pitchGraphCanvasEl);
@@ -668,6 +684,9 @@ function mount(_slot: HTMLElement): void {
   });
   btnStartWarmup.addEventListener('click', () => {
     startWarmup();
+  });
+  btnStopWarmup.addEventListener('click', () => {
+    stopWarmup();
   });
   btnStartRehearsal.addEventListener('click', () => {
     const playBtn = document.getElementById('btn-play') as HTMLButtonElement | null;


### PR DESCRIPTION
### Motivation
- Users could not cancel an in-progress warm-up once started, forcing a page reload or waiting the full duration. 
- The warm-up UI should expose a clear, accessible control to end the warm-up early and transition to rehearsal-ready state. 
- Agent guidance should require PR bodies to include `Closes #N` so issues are auto-closed on merge.

### Description
- Add a dedicated `⏹ Stop warm-up` button to the warm-up panel in `frontend/index.html` and include it in the DOM. 
- Update `syncWarmupUi()` in `frontend/src/features/pitch-overlay/index.ts` to toggle visibility and disabled state of Start / Stop / Start rehearsal controls based on `warmupActive`. 
- Implement `stopWarmup()` to cancel the active warm-up, clear the warm-up target note, and update the UI to a rehearsal-ready message, and wire it to the new stop button click handler. 
- Update `AGENTS.md` and `CLAUDE.md` to require PR descriptions include `Closes #N` (e.g. `Closes #179`).

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both completed successfully. 
- Ran `uv run pytest -v`, which failed to collect due to the environment missing PortAudio (`sounddevice` error) and missing `torch`, so backend tests could not be fully executed here. 
- Ran `cd frontend && npm test`, which executed the test suite; there are pre-existing frontend test failures unrelated to this change (3 failing assertions in `progress-history.test.ts` and `timeline-sync.test.ts`). 
- Attempted `cd frontend && npm run build`, which fails in this environment due to pre-existing TypeScript unused-variable errors unrelated to the warm-up UI change. 

Closes #179

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b1b1507483278202a9694629b031)