### PR TITLE
fix: improve Play button feedback when no score is loaded

### DIFF
--- a/frontend/src/features/playback/index.test.ts
+++ b/frontend/src/features/playback/index.test.ts
@@ -1,0 +1,117 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setAppStatusMock = vi.fn();
+const getSessionMock = vi.fn(() => null);
+
+vi.mock('../../services/score-session', () => ({
+  getSession: () => getSessionMock(),
+  onScoreLoaded: () => () => {},
+  onScoreCleared: () => () => {},
+  onPartChanged: () => () => {},
+}));
+
+vi.mock('../../services/status', () => ({
+  setAppStatus: (...args: unknown[]) => setAppStatusMock(...args),
+}));
+
+vi.mock('../../services/cursor-projection', () => ({
+  recordBeatSample: () => {},
+  resetProjection: () => {},
+  getCursorX: () => 0,
+}));
+
+vi.mock('../../services/progress-history', () => ({
+  finishPracticeSessionCapture: () => {},
+  startPracticeSessionCapture: () => {},
+}));
+
+vi.mock('../../services/playback-sync', () => ({
+  emitPlaybackSyncEvent: () => {},
+}));
+
+vi.mock('../../transport/controls', () => ({
+  beatToMs: () => 0,
+  postPlayback: vi.fn(async () => ({ t_ms: 0 })),
+  setPlaybackTempo: vi.fn(async () => ({})),
+  startPlayback: vi.fn(async () => ({ t_ms: 0 })),
+  seekPlayback: vi.fn(async () => ({ t_ms: 0 })),
+}));
+
+vi.mock('../../practice/session-summary', () => ({
+  sessionSummaryTracker: {
+    recordSample: () => {},
+    finishSession: () => null,
+    reset: () => {},
+  },
+}));
+
+vi.mock('../../services/audio-preflight', () => ({
+  ensureAudioPreflightReady: vi.fn(async () => true),
+}));
+
+vi.mock('../../services/loop-region', () => ({
+  clearLoopRegion: () => {},
+  getLoopRegion: () => ({ active: false, startBeat: 0, endBeat: 0 }),
+  setLoopEnd: () => {},
+  setLoopStart: () => {},
+}));
+
+vi.mock('../../media-session', () => ({
+  installMediaSession: () => {},
+  updateMediaSessionMetadata: () => {},
+  updateMediaSessionState: () => {},
+}));
+
+import { playbackFeature } from './index';
+
+function installPlaybackDom(): void {
+  document.body.innerHTML = `
+    <div id="slot-playback"></div>
+    <button id="btn-play">Play</button>
+    <button id="btn-pause">Pause</button>
+    <button id="btn-stop">Stop</button>
+    <button id="btn-rewind">Rewind</button>
+    <div id="headphone-warning" class="hidden"></div>
+    <button id="warning-dismiss">Dismiss</button>
+    <button id="btn-summary-close">Close</button>
+    <button id="btn-summary-retry">Retry</button>
+    <button id="btn-summary-replay">Replay</button>
+    <div id="session-summary-modal" class="hidden"></div>
+    <pre id="session-summary-content"></pre>
+    <input id="tempo-slider" value="100" />
+    <span id="tempo-label">100%</span>
+    <select id="settings-device"><option value=""></option></select>
+  `;
+}
+
+describe('playbackFeature', () => {
+  beforeEach(() => {
+    setAppStatusMock.mockReset();
+    getSessionMock.mockReset();
+    getSessionMock.mockReturnValue(null);
+    installPlaybackDom();
+  });
+
+  it('disables play on mount when no score session exists', () => {
+    const slot = document.getElementById('slot-playback') as HTMLDivElement;
+    playbackFeature.mount(slot);
+
+    const btnPlay = document.getElementById('btn-play') as HTMLButtonElement;
+    expect(btnPlay.disabled).toBe(true);
+
+    playbackFeature.unmount();
+  });
+
+  it('shows a status message when play is triggered without a score session', () => {
+    const slot = document.getElementById('slot-playback') as HTMLDivElement;
+    playbackFeature.mount(slot);
+
+    const btnPlay = document.getElementById('btn-play') as HTMLButtonElement;
+    btnPlay.disabled = false;
+    btnPlay.click();
+
+    expect(setAppStatusMock).toHaveBeenCalledWith('Load a score first', 'warning');
+
+    playbackFeature.unmount();
+  });
+});

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -350,7 +350,10 @@ function mount(_slot: HTMLElement): void {
 
   btnPlay.addEventListener('click', async () => {
     const session = getSession();
-    if (!session) return;
+    if (!session) {
+      setAppStatus('Load a score first', 'warning');
+      return;
+    }
     const { engine, cursor } = session;
     if (engine.state === 'playing') return;
     const preflightReady = await ensureAudioPreflightReady();


### PR DESCRIPTION
### Motivation
- The Play button silently did nothing when clicked with no score loaded; UX should either disable Play initially or show a brief status message so the user knows what to do.

### Description
- Added a no-session guard to the Play click handler that calls `setAppStatus('Load a score first', 'warning')` and returns when `getSession()` is null (`frontend/src/features/playback/index.ts`).
- Kept existing transport state logic intact; this change provides explicit feedback in addition to `syncTransportButtons()` disabling Play when appropriate.
- Added unit tests for the playback feature (`frontend/src/features/playback/index.test.ts`) which mock dependencies and assert that Play is disabled on mount with no session and that a no-session Play click triggers the `setAppStatus` warning.
- Modified UI behaviour only in the Play button handler; no backend or transport protocol changes were made.

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both completed successfully.
- Ran full Python test suite with `uv run pytest -v`, which failed in this environment during collection due to missing system libraries (`PortAudio`) and missing `torch` module; these failures are environmental and unrelated to the frontend change.
- Ran the frontend unit test for the new playback tests with `npm --prefix frontend test -- src/features/playback/index.test.ts`, and the two Vitest tests passed. Closes #159

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b8008fdc8327b8cfd105551996a9)