### PR TITLE
test: add integration tests for /score endpoint contract and error cases

### DIFF
--- a/backend/tests/test_api_score_endpoint.py
+++ b/backend/tests/test_api_score_endpoint.py
@@ -150,5 +150,4 @@ def test_score_endpoint_handles_corrupted_xml(client: TestClient) -> None:
     )
 
     assert response.status_code == 422
-    assert response.status_code != 200
     assert "parse" in response.json()["detail"].lower()


### PR DESCRIPTION
### Motivation
- Ensure the critical `/score` endpoint is covered end-to-end so the API contract and key error cases are validated. 
- Prevent regressions in MusicXML parsing behavior (happy path and common failure modes) by exercising the real parser with an existing fixture.

### Description
- Add `backend/tests/test_api_score_endpoint.py` implementing FastAPI `TestClient` integration tests that validate the happy-path upload and the `ScoreModel` contract keys (`title`, `parts`, `notes`, `tempo_marks`, `time_signatures`, `total_beats`).
- Include assertions that the first tempo mark for the Homeward Bound fixture is approximately `72.0` BPM with ±1 tolerance.
- Add error-case tests asserting unsupported file suffix returns `400` with `"Unsupported file type"`, missing file triggers a FastAPI validation `422`, and corrupted XML returns a non-200 parse failure (`422` containing `"parse"`).
- Install test-only lightweight stubs for `sounddevice` and `torch` inside the test fixture so the application can be imported in environments that lack PortAudio or PyTorch without changing production code.

### Testing
- Ran linter: `uv run ruff check backend/ --fix` and `uv run ruff check backend/` and both succeeded.
- Ran the new test file: `uv run pytest -v backend/tests/test_api_score_endpoint.py` and all tests passed (4 passed, 0 failed).
- Running the full test suite with `uv run pytest -v` in this environment still fails during collection due to unrelated missing native dependencies (`PortAudio` via `sounddevice`) and missing `torch` for other tests, so full-suite CI behavior is unchanged by this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b82c5ebc8327a30b11700a123eb5)

Closes #156 