### PR TITLE
fix: retry soundfont mirror and make fallback banner dismissible

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -72,8 +72,21 @@
       padding: 8px 20px;
       font-size: 0.85rem;
       flex-shrink: 0;
+      align-items: center;
+      gap: 12px;
     }
-    #error-banner.visible { display: block; }
+    #error-banner.visible { display: flex; }
+    #error-banner-message { flex: 1; }
+    #error-banner-dismiss {
+      background: transparent;
+      border: 1px solid #e57386;
+      color: #ffd0d8;
+      border-radius: 4px;
+      padding: 2px 8px;
+      cursor: pointer;
+      font-size: 0.8rem;
+    }
+    #error-banner-dismiss.hidden { display: none; }
 
     /* ── Toast notifications ── */
     #toast-stack {
@@ -553,7 +566,10 @@
     </div>
   </header>
 
-  <div id="error-banner" role="alert"></div>
+  <div id="error-banner" role="alert">
+    <span id="error-banner-message"></span>
+    <button id="error-banner-dismiss" class="hidden" aria-label="Dismiss error">Dismiss</button>
+  </div>
   <div id="toast-stack" aria-live="polite" aria-atomic="false"></div>
 
   <div id="headphone-warning" class="hidden">

--- a/frontend/src/features/score-loader/index.ts
+++ b/frontend/src/features/score-loader/index.ts
@@ -193,7 +193,7 @@ function mount(slot: HTMLElement): void {
 
     // Kick off soundfont loading early (idempotent) so it overlaps with parse.
     ensureSoundfontLoaded((err) => {
-      showErrorBanner('Soundfont failed to load; using synth fallback audio.');
+      showErrorBanner('Soundfont failed to load; using synth fallback audio.', { dismissible: true });
       setAppStatus('soundfont unavailable — using synthesised tones', 'error');
       showToast('Soundfont unavailable — using synthesised tones', {
         variant: 'warning',

--- a/frontend/src/playback/soundfont.test.ts
+++ b/frontend/src/playback/soundfont.test.ts
@@ -1,7 +1,12 @@
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SoundfontLoader } from './soundfont';
 
 describe('SoundfontLoader.parseNoteMap', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
   it('parses MIDI.js assignment with trailing non-JSON content', () => {
     const js = [
       'MIDI.Soundfont.acoustic_grand_piano = {"A0":"data:audio/mp3;base64,QQ=="};',
@@ -12,8 +17,6 @@ describe('SoundfontLoader.parseNoteMap', () => {
       A0: 'data:audio/mp3;base64,QQ==',
     });
   });
-
-
 
   it('parses when sample payload contains braces before object end', () => {
     const js = 'MIDI.Soundfont.acoustic_grand_piano = {"A0":"data:audio/mp3;base64,QQ==","A1":"value}still-string"};';
@@ -28,5 +31,28 @@ describe('SoundfontLoader.parseNoteMap', () => {
     expect(() => SoundfontLoader.parseNoteMap('<!doctype html>403 Forbidden')).toThrow(
       'Could not parse soundfont JS: no JSON object found',
     );
+  });
+
+  it('retries a secondary mirror when the first mirror has corrupt JSON', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => 'MIDI.Soundfont.acoustic_grand_piano = {invalid};',
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        text: async () => 'MIDI.Soundfont.acoustic_grand_piano = {"A0":"data:audio/mp3;base64,QQ=="};',
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const decodeAudioData = vi.fn().mockResolvedValue({} as AudioBuffer);
+    const ctx = { decodeAudioData } as unknown as AudioContext;
+
+    const loader = new SoundfontLoader();
+    await loader.load(ctx);
+
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(loader.loaded).toBe(true);
+    expect(loader.sampleCount).toBe(1);
   });
 });

--- a/frontend/src/playback/soundfont.ts
+++ b/frontend/src/playback/soundfont.ts
@@ -15,8 +15,10 @@
  * at the local path (e.g. '/assets/acoustic_grand_piano-mp3.js').
  */
 
-const SOUNDFONT_URL =
-  'https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/acoustic_grand_piano-mp3.js';
+const SOUNDFONT_URLS = [
+  'https://gleitz.github.io/midi-js-soundfonts/FluidR3_GM/acoustic_grand_piano-mp3.js',
+  'https://cdn.jsdelivr.net/gh/gleitz/midi-js-soundfonts@gh-pages/FluidR3_GM/acoustic_grand_piano-mp3.js',
+] as const;
 
 const SOUNDFONT_ASSIGNMENT_RE = /MIDI\.Soundfont\.[A-Za-z0-9_]+\s*=/;
 
@@ -60,16 +62,10 @@ export class SoundfontLoader {
   async load(ctx: AudioContext): Promise<void> {
     if (this._loaded) return;
 
-    // 1. Fetch the MIDI.js-format soundfont JS file
-    const resp = await fetch(SOUNDFONT_URL);
-    if (!resp.ok) {
-      throw new Error(`Soundfont fetch failed (HTTP ${resp.status}): ${SOUNDFONT_URL}`);
-    }
-    const js = await resp.text();
-
-    // 2. Extract the embedded JSON object
-    // File structure: MIDI.Soundfont.acoustic_grand_piano = { "A0": "data:…", … }
-    const noteMap = SoundfontLoader.parseNoteMap(js);
+    // 1. Fetch the MIDI.js-format soundfont JS file.
+    // Some CDN mirrors occasionally return a corrupt/truncated payload; we
+    // retry against a secondary mirror before falling back to synth mode.
+    const noteMap = await SoundfontLoader.loadNoteMapFromMirror();
 
     // 3. Decode all samples concurrently
     const entries = Object.entries(noteMap);
@@ -136,6 +132,24 @@ export class SoundfontLoader {
   // Exposed for tests
   static midiToNoteName = midiToNoteName;
   static noteNameToMidi = noteNameToMidi;
+
+  private static async loadNoteMapFromMirror(): Promise<Record<string, string>> {
+    let lastError: unknown;
+    for (const url of SOUNDFONT_URLS) {
+      try {
+        const resp = await fetch(url);
+        if (!resp.ok) {
+          throw new Error(`Soundfont fetch failed (HTTP ${resp.status}): ${url}`);
+        }
+        const js = await resp.text();
+        return SoundfontLoader.parseNoteMap(js);
+      } catch (err) {
+        lastError = err;
+      }
+    }
+    throw lastError ?? new Error('Soundfont fetch failed from all mirrors');
+  }
+
   static parseNoteMap(js: string): Record<string, string> {
     const assignment = js.match(SOUNDFONT_ASSIGNMENT_RE);
     if (!assignment || assignment.index === undefined) {

--- a/frontend/src/services/backend.test.ts
+++ b/frontend/src/services/backend.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+describe('backend error banner', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    document.body.innerHTML = [
+      '<div id="error-banner" role="alert">',
+      '  <span id="error-banner-message"></span>',
+      '  <button id="error-banner-dismiss" class="hidden">Dismiss</button>',
+      '</div>',
+    ].join('');
+  });
+
+  it('shows a dismiss button for dismissible banners and clears on click', async () => {
+    const backend = await import('./backend');
+
+    backend.showErrorBanner('Soundfont failed to load', { dismissible: true });
+
+    const banner = document.getElementById('error-banner') as HTMLDivElement;
+    const message = document.getElementById('error-banner-message') as HTMLSpanElement;
+    const dismiss = document.getElementById('error-banner-dismiss') as HTMLButtonElement;
+
+    expect(banner.classList.contains('visible')).toBe(true);
+    expect(message.textContent).toBe('Soundfont failed to load');
+    expect(dismiss.classList.contains('hidden')).toBe(false);
+
+    dismiss.click();
+    expect(banner.classList.contains('visible')).toBe(false);
+    expect(message.textContent).toBe('');
+  });
+
+  it('keeps dismiss button hidden for non-dismissible banners', async () => {
+    const backend = await import('./backend');
+
+    backend.showErrorBanner('Cannot reach backend');
+
+    const dismiss = document.getElementById('error-banner-dismiss') as HTMLButtonElement;
+    expect(dismiss.classList.contains('hidden')).toBe(true);
+  });
+});

--- a/frontend/src/services/backend.ts
+++ b/frontend/src/services/backend.ts
@@ -7,14 +7,46 @@
 import { setAppStatus } from './status';
 
 const errorBannerEl = document.getElementById('error-banner') as HTMLDivElement;
+const errorBannerMessageEl = document.getElementById('error-banner-message') as HTMLSpanElement | null;
+const errorBannerDismissEl = document.getElementById('error-banner-dismiss') as HTMLButtonElement | null;
 
-export function showErrorBanner(message: string): void {
-  errorBannerEl.textContent = message;
+type ShowErrorBannerOptions = {
+  dismissible?: boolean;
+};
+
+if (errorBannerDismissEl) {
+  errorBannerDismissEl.addEventListener('click', () => {
+    clearErrorBanner();
+  });
+}
+
+export function showErrorBanner(message: string, options: ShowErrorBannerOptions = {}): void {
+  const { dismissible = false } = options;
+
+  if (errorBannerMessageEl) {
+    errorBannerMessageEl.textContent = message;
+  } else {
+    errorBannerEl.textContent = message;
+  }
+
+  if (errorBannerDismissEl) {
+    errorBannerDismissEl.classList.toggle('hidden', !dismissible);
+  }
+
   errorBannerEl.classList.add('visible');
 }
 
 export function clearErrorBanner(): void {
-  errorBannerEl.textContent = '';
+  if (errorBannerMessageEl) {
+    errorBannerMessageEl.textContent = '';
+  } else {
+    errorBannerEl.textContent = '';
+  }
+
+  if (errorBannerDismissEl) {
+    errorBannerDismissEl.classList.add('hidden');
+  }
+
   errorBannerEl.classList.remove('visible');
 }
 


### PR DESCRIPTION
### Motivation

- The primary soundfont CDN can occasionally return corrupt/truncated JS/JSON which causes `JSON.parse` failures and forces an unnecessary synth fallback.  
- When the soundfont load fails an error banner appears persistently with no way for the user to dismiss it.

### Description

- Add mirror retry logic to `SoundfontLoader` by replacing the single `SOUNDFONT_URL` with `SOUNDFONT_URLS` and adding `loadNoteMapFromMirror()` which attempts each mirror and parses the first valid payload (`frontend/src/playback/soundfont.ts`).
- Make the top error banner dismissible by adding a message span and dismiss button to the DOM and styles in `index.html`, and extend `showErrorBanner`/`clearErrorBanner` to accept a `dismissible` option and handle the dismiss button (`frontend/index.html`, `frontend/src/services/backend.ts`).
- Use the dismissible option for the soundfont fallback notification in the score loader (`frontend/src/features/score-loader/index.ts`).
- Add/adjust frontend tests: a regression test verifying mirror retry for corrupt first-mirror payload (`frontend/src/playback/soundfont.test.ts`) and tests for the dismissible banner behavior (`frontend/src/services/backend.test.ts`).

### Testing

- Ran linting with `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both of which passed.  
- Ran the Python test suite with `uv run pytest -v` which failed to collect due to missing system deps in this environment (`PortAudio` and `torch`), causing collection errors.  
- Ran the full frontend test suite with `npm --prefix frontend test`, which surfaced pre-existing unrelated frontend failures (three failing tests in unrelated suites).  
- Ran targeted frontend tests for the changes with `npm --prefix frontend test -- src/playback/soundfont.test.ts src/services/backend.test.ts`, and those tests passed.  
- Launched the frontend dev server and exercised the new banner flow (automated browser script captured a screenshot showing the dismiss button) to validate the UI integration.  

Closes #170

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6b7dbcd608327a6917dd62395efbe)