### PR TITLE
test: add frontend coverage for warm-up stop button behavior

### DIFF
--- a/frontend/src/features/pitch-overlay/index.test.ts
+++ b/frontend/src/features/pitch-overlay/index.test.ts
@@ -201,11 +201,14 @@ describe('pitchOverlayFeature warm-up controls', () => {
     const stop = document.getElementById('btn-stop-warmup') as HTMLButtonElement;
     const status = document.getElementById('warmup-status') as HTMLSpanElement;
 
-    stop.disabled = false;
-    const before = status.textContent;
-    stop.click();
-
-    expect(status.textContent).toBe(before);
+    // The stop button must remain disabled while idle — disabled buttons do not
+    // fire native click events, so this is the actual no-op mechanism.
+    expect(stop.disabled).toBe(true);
     expect(stop.classList.contains('hidden')).toBe(true);
+
+    // Dispatch a programmatic click to verify the handler guard also ignores it.
+    const before = status.textContent;
+    stop.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+    expect(status.textContent).toBe(before);
   });
 });


### PR DESCRIPTION
### Motivation
- The warm-up stop button and `stopWarmup()` behavior added earlier had no frontend tests and lacked coverage for UI visibility and state transitions.
- Add focused unit tests to ensure `btn-start-warmup` / `btn-stop-warmup` visibility, `stopWarmup()` state resets, and that clicking stop while idle is a no-op.

### Description
- Add `frontend/src/features/pitch-overlay/index.test.ts`, a Vitest suite that mounts `pitchOverlayFeature` with a full DOM fixture and lightweight mocks for dependent modules. 
- The tests exercise warm-up lifecycle: idle visibility, active visibility after `startWarmup()`, `stopWarmup()` resetting `warmupActive`/`warmupTargetMidi` and updating the status text, and no-op behavior when stop is clicked while idle. 
- The tests stub global `WebSocket` and RAF/CAF and use mocked implementations for pitch/warmup collaborators to keep the suite hermetic. 
- Closes #207.

### Testing
- `cd frontend && npm test -- --run src/features/pitch-overlay/index.test.ts` ran the new file and all 4 tests passed. 
- `cd frontend && npm test` ran the full frontend suite and all frontend tests passed (36 files, 194 tests). 
- `uv run ruff check backend/ --fix` and `uv run ruff check backend/` completed with no lint failures. 
- `uv run pytest -v` failed in this environment during collection due to missing system deps (`PortAudio`) and missing `torch`, which is an environment constraint rather than a regression in these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6c43f1b5c832789b95be61c0c0f9f)