### PR TITLE
chore: remove dead frontend smoke e2e spec

### DIFF
--- a/frontend/tests/e2e/smoke.spec.ts
+++ b/frontend/tests/e2e/smoke.spec.ts
@@ -1,9 +1,0 @@
-import { expect, test } from '@playwright/test';
-
-test('loads sing-attune shell', async ({ page }) => {
-  await page.goto('/');
-
-  await expect(page).toHaveTitle(/sing-attune/i);
-  await expect(page.getByRole('heading', { level: 1, name: 'sing-attune' })).toBeVisible();
-  await expect(page.getByRole('button', { name: /Play \(Space\)/i })).toBeVisible();
-});

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -4,6 +4,6 @@ export default defineConfig({
   test: {
     environment: 'jsdom',
     globals: false,
-    exclude: [...configDefaults.exclude, 'e2e/**', 'tests/e2e/**'],
+    exclude: [...configDefaults.exclude, 'e2e/**'],
   },
 });


### PR DESCRIPTION
### Motivation

- The spec `frontend/tests/e2e/smoke.spec.ts` was never discovered by Playwright because `playwright.config.ts` sets `testDir: './e2e'`, and the stray file was being picked up by Vitest instead causing confusion. 
- Removing the dead file lets the Vitest `exclude` be simplified and avoids accidental unit-test collection of Playwright specs.

### Description

- Deleted `frontend/tests/e2e/smoke.spec.ts` which lived under `frontend/tests/e2e/` and was not used by Playwright. 
- Simplified `frontend/vitest.config.ts` by removing the unnecessary `'tests/e2e/**'` exclusion so it now excludes only `e2e/**`. 
- PR is intended to close the issue tracking this cleanup: `Closes #217`.

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which both passed. 
- Ran `npm test` in `frontend` (Vitest) and all frontend unit tests passed. 
- Ran `uv run pytest -v` which failed during collection in this environment due to missing system libs (`PortAudio`) and missing `torch`, so backend test collection could not complete. 
- Attempted `npm run test:e2e` but the `playwright` binary is not available in this environment, so e2e execution could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6ce88d4148327a037d9011d771d4d)