### PR TITLE
fix: hide Pause Space shortcut label while idle

### DIFF
--- a/frontend/src/features/playback/index.test.ts
+++ b/frontend/src/features/playback/index.test.ts
@@ -104,6 +104,18 @@ describe('playbackFeature', () => {
     playbackFeature.unmount!();
   });
 
+  it('does not show the Space shortcut on Pause when transport is idle', () => {
+    const slot = document.getElementById('slot-playback') as HTMLDivElement;
+    playbackFeature.mount(slot);
+
+    const btnPause = document.getElementById('btn-pause') as HTMLButtonElement;
+    expect(btnPause.disabled).toBe(true);
+    expect(btnPause.innerHTML).toContain('Pause');
+    expect(btnPause.innerHTML).not.toContain('(Space)');
+
+    playbackFeature.unmount!();
+  });
+
   it('shows a status message when play is triggered without a score session', () => {
     const slot = document.getElementById('slot-playback') as HTMLDivElement;
     playbackFeature.mount(slot);

--- a/frontend/src/features/playback/index.ts
+++ b/frontend/src/features/playback/index.ts
@@ -224,6 +224,23 @@ function hideSessionSummary(): void {
   modal?.classList.add('hidden');
 }
 
+function setPauseButtonState(button: HTMLButtonElement, state: 'idle' | 'playing' | 'paused'): void {
+  if (state === 'playing') {
+    button.disabled = false;
+    button.innerHTML = '&#9646;&#9646; Pause (Space)';
+    return;
+  }
+
+  if (state === 'paused') {
+    button.disabled = false;
+    button.innerHTML = '&#9654; Resume (Space)';
+    return;
+  }
+
+  button.disabled = true;
+  button.innerHTML = '&#9646;&#9646; Pause';
+}
+
 function isSessionSummaryOpen(): boolean {
   const modal = document.getElementById('session-summary-modal') as HTMLDivElement | null;
   return Boolean(modal && !modal.classList.contains('hidden'));
@@ -282,22 +299,10 @@ function mount(_slot: HTMLElement): void {
 
     // Pause/Resume: enabled when playing or paused.
     if (!session) {
-      btnPause.disabled = true;
-      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
+      setPauseButtonState(btnPause, 'idle');
       return;
     }
-    if (playbackState === 'playing') {
-      btnPause.disabled = false;
-      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
-      return;
-    }
-    if (playbackState === 'paused') {
-      btnPause.disabled = false;
-      btnPause.innerHTML = '&#9654; Resume (Space)';
-      return;
-    }
-    btnPause.disabled = true;
-    btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
+    setPauseButtonState(btnPause, playbackState);
   }
 
   const unsubscribeLoaded = onScoreLoaded((session) => {
@@ -315,18 +320,15 @@ function mount(_slot: HTMLElement): void {
   function syncPauseButton(): void {
     const session = getSession();
     if (!session || session.engine.state === 'idle') {
-      btnPause.disabled = true;
-      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
+      setPauseButtonState(btnPause, 'idle');
       return;
     }
     if (session.engine.state === 'playing') {
-      btnPause.disabled = false;
-      btnPause.innerHTML = '&#9646;&#9646; Pause (Space)';
+      setPauseButtonState(btnPause, 'playing');
       return;
     }
     if (session.engine.state === 'paused') {
-      btnPause.disabled = false;
-      btnPause.innerHTML = '&#9654; Resume (Space)';
+      setPauseButtonState(btnPause, 'paused');
     }
   }
 


### PR DESCRIPTION
### Motivation
- Fix misleading UI where both Play and Pause buttons show `(Space)` in the idle state so only Play advertises the Space shortcut before playback starts.

### Description
- Add `setPauseButtonState(button, state)` helper to centralize Pause button label and disabled-state updates. 
- Use the helper from `syncTransportButtons` and `syncPauseButton` so the Pause button omits `(Space)` when `idle` and shows `(Space)` only when active (`playing`/`paused`).
- Update frontend unit tests to assert the Pause button is disabled and does not contain `(Space)` while transport is idle.

### Testing
- Ran linter: `uv run ruff check backend/ --fix` and `uv run ruff check backend/` — both passed. 
- Ran full Python test suite: `uv run pytest -v` — collection failed in this environment due to missing system/library dependencies (`PortAudio`) and missing `torch`, so backend tests could not complete. 
- Ran frontend unit tests: `npm --prefix frontend test -- src/features/playback/index.test.ts` — the playback tests passed.

Closes #221

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6d486569c83278d89d7adf081d31a)