### PR TITLE
feat: Electron shell launches backend with dynamic port and lifecycle handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ This keeps the backend real-time pipeline simple while score-aware interpretatio
 
 ## Status
 
-🚧 **Early development** — backend complete through Day 7, frontend score rendering (Day 8a) now working.
+🚧 **Early development** — backend complete through Day 7, frontend score rendering (Day 8a) now working, Electron bootstrap in progress (Day 16a).
 
 | Component | Status |
 |-----------|--------|
@@ -87,7 +87,7 @@ This keeps the backend real-time pipeline simple while score-aware interpretatio
 | Score playback (Web Audio) | 🔲 Day 9 |
 | Real-time pitch overlay | ✅ Done (Day 10) |
 | Transport controls | 🔲 Day 11 |
-| Electron packaging | 🔲 Day 16 |
+| Electron packaging | 🟡 In progress (Day 16a backend launcher) |
 
 ---
 
@@ -215,6 +215,9 @@ backend/
   main.py         FastAPI app, REST endpoints, WebSocket pitch stream
 frontend/
   src/            Vite + TypeScript — score renderer, pitch canvas, playback, controls
+electron/
+  main.js         Electron shell: backend process lifecycle + dynamic port + splash
+  preload.js      Secure IPC bridge for backend runtime config
 .github/
   workflows/      PR review: ruff + pytest + frontend-test + e2e + Codecov + Claude AI review
   scripts/        claude_review.py — AI review script

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,0 +1,265 @@
+const { app, BrowserWindow, ipcMain } = require('electron');
+const path = require('node:path');
+const fs = require('node:fs');
+const http = require('node:http');
+const net = require('node:net');
+const { spawn } = require('node:child_process');
+
+const HOST = '127.0.0.1';
+const BACKEND_START_TIMEOUT_MS = 5_000;
+const BACKEND_RESTART_DELAY_MS = 1_000;
+const BACKEND_STOP_GRACE_MS = 2_000;
+
+let mainWindow = null;
+let splashWindow = null;
+let backendProcess = null;
+let backendPort = null;
+let restartTimer = null;
+let shuttingDown = false;
+
+function createSplashWindow() {
+  splashWindow = new BrowserWindow({
+    width: 420,
+    height: 220,
+    frame: false,
+    resizable: false,
+    alwaysOnTop: true,
+    show: false,
+    transparent: false,
+    backgroundColor: '#101010',
+  });
+
+  splashWindow.loadFile(path.join(__dirname, 'splash.html'));
+  splashWindow.once('ready-to-show', () => splashWindow?.show());
+}
+
+function createMainWindow(port) {
+  mainWindow = new BrowserWindow({
+    width: 1400,
+    height: 900,
+    show: false,
+    autoHideMenuBar: true,
+    webPreferences: {
+      preload: path.join(__dirname, 'preload.js'),
+      contextIsolation: true,
+      nodeIntegration: false,
+      additionalArguments: [`--sing-attune-backend-port=${String(port)}`],
+    },
+  });
+
+  mainWindow.once('ready-to-show', () => {
+    splashWindow?.close();
+    splashWindow = null;
+    mainWindow?.show();
+  });
+
+  const appUrl = `http://${HOST}:${port}`;
+  mainWindow.loadURL(appUrl).catch((error) => {
+    console.error('[electron] Failed to load renderer URL:', error);
+  });
+}
+
+function resolveBackendExecutable() {
+  const fromEnv = process.env.SING_ATTUNE_BACKEND_BIN;
+  if (fromEnv) {
+    return fromEnv;
+  }
+
+  const ext = process.platform === 'win32' ? '.exe' : '';
+  const binaryName = `sing-attune-backend${ext}`;
+  const candidates = [
+    path.join(process.resourcesPath, 'backend', binaryName),
+    path.join(app.getAppPath(), 'backend-dist', binaryName),
+  ];
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(candidate)) {
+      return candidate;
+    }
+  }
+
+  throw new Error(
+    `Could not locate backend executable. Checked: ${candidates.join(', ')}. ` +
+      'Set SING_ATTUNE_BACKEND_BIN to override.',
+  );
+}
+
+function findOpenPort() {
+  return new Promise((resolve, reject) => {
+    const server = net.createServer();
+    server.unref();
+
+    server.on('error', reject);
+    server.listen(0, HOST, () => {
+      const address = server.address();
+      if (!address || typeof address === 'string') {
+        server.close(() => reject(new Error('Unable to determine dynamic backend port.')));
+        return;
+      }
+
+      const { port } = address;
+      server.close((closeError) => {
+        if (closeError) {
+          reject(closeError);
+          return;
+        }
+
+        resolve(port);
+      });
+    });
+  });
+}
+
+function waitForBackendHealthy(port, timeoutMs) {
+  const start = Date.now();
+
+  return new Promise((resolve, reject) => {
+    const poll = () => {
+      const req = http.get(
+        {
+          hostname: HOST,
+          port,
+          path: '/health',
+          timeout: 1_000,
+        },
+        (res) => {
+          if (res.statusCode === 200) {
+            res.resume();
+            resolve();
+            return;
+          }
+
+          res.resume();
+          retry();
+        },
+      );
+
+      req.on('error', retry);
+      req.on('timeout', () => {
+        req.destroy(new Error('Health check timeout'));
+      });
+    };
+
+    const retry = () => {
+      if (Date.now() - start >= timeoutMs) {
+        reject(new Error(`Backend failed to become healthy within ${timeoutMs}ms.`));
+        return;
+      }
+
+      setTimeout(poll, 150);
+    };
+
+    poll();
+  });
+}
+
+async function startBackend() {
+  const executable = resolveBackendExecutable();
+  backendPort = await findOpenPort();
+
+  const args = ['--host', HOST, '--port', String(backendPort)];
+  backendProcess = spawn(executable, args, {
+    stdio: 'pipe',
+    env: {
+      ...process.env,
+      SING_ATTUNE_BACKEND_PORT: String(backendPort),
+    },
+  });
+
+  backendProcess.stdout.on('data', (chunk) => {
+    process.stdout.write(`[backend] ${String(chunk)}`);
+  });
+
+  backendProcess.stderr.on('data', (chunk) => {
+    process.stderr.write(`[backend] ${String(chunk)}`);
+  });
+
+  backendProcess.on('exit', (code, signal) => {
+    const unexpected = !shuttingDown && code !== 0;
+    console.error(`[electron] Backend exited (code=${code}, signal=${signal}).`);
+    backendProcess = null;
+
+    if (unexpected) {
+      scheduleBackendRestart();
+    }
+  });
+
+  await waitForBackendHealthy(backendPort, BACKEND_START_TIMEOUT_MS);
+
+  process.env.SING_ATTUNE_BACKEND_PORT = String(backendPort);
+}
+
+function scheduleBackendRestart() {
+  if (restartTimer || shuttingDown) {
+    return;
+  }
+
+  restartTimer = setTimeout(async () => {
+    restartTimer = null;
+
+    try {
+      await startBackend();
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        await mainWindow.loadURL(`http://${HOST}:${backendPort}`);
+      }
+    } catch (error) {
+      console.error('[electron] Backend restart failed:', error);
+      scheduleBackendRestart();
+    }
+  }, BACKEND_RESTART_DELAY_MS);
+}
+
+function stopBackend() {
+  shuttingDown = true;
+
+  if (restartTimer) {
+    clearTimeout(restartTimer);
+    restartTimer = null;
+  }
+
+  if (!backendProcess || backendProcess.killed) {
+    return;
+  }
+
+  backendProcess.kill('SIGTERM');
+
+  setTimeout(() => {
+    if (backendProcess && !backendProcess.killed) {
+      backendProcess.kill('SIGKILL');
+    }
+  }, BACKEND_STOP_GRACE_MS);
+}
+
+function registerIpcHandlers() {
+  ipcMain.handle('backend:get-config', () => ({
+    host: HOST,
+    port: backendPort,
+    baseUrl: backendPort ? `http://${HOST}:${backendPort}` : null,
+  }));
+}
+
+async function bootstrap() {
+  createSplashWindow();
+  registerIpcHandlers();
+
+  try {
+    await startBackend();
+    createMainWindow(backendPort);
+  } catch (error) {
+    console.error('[electron] Failed to start backend:', error);
+    app.quit();
+  }
+}
+
+app.whenReady().then(bootstrap);
+app.on('before-quit', stopBackend);
+app.on('window-all-closed', () => {
+  if (process.platform !== 'darwin') {
+    app.quit();
+  }
+});
+app.on('activate', () => {
+  if (BrowserWindow.getAllWindows().length === 0 && backendPort) {
+    createMainWindow(backendPort);
+  }
+});

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "sing-attune-electron",
+  "version": "0.1.0",
+  "private": true,
+  "main": "main.js",
+  "scripts": {
+    "start": "electron ."
+  },
+  "devDependencies": {
+    "electron": "^31.0.2"
+  }
+}

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -1,0 +1,18 @@
+const { contextBridge, ipcRenderer } = require('electron');
+
+function readBackendPortFromArgv() {
+  const prefix = '--sing-attune-backend-port=';
+  const match = process.argv.find((arg) => arg.startsWith(prefix));
+  if (!match) {
+    return null;
+  }
+
+  const rawPort = match.slice(prefix.length);
+  const parsed = Number.parseInt(rawPort, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+contextBridge.exposeInMainWorld('singAttune', {
+  getBackendPort: () => readBackendPortFromArgv(),
+  getBackendConfig: () => ipcRenderer.invoke('backend:get-config'),
+});

--- a/electron/splash.html
+++ b/electron/splash.html
@@ -1,0 +1,52 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>sing-attune</title>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Inter, Segoe UI, sans-serif;
+      }
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: grid;
+        place-items: center;
+        background: radial-gradient(circle at 30% 20%, #1c1c1c, #090909 70%);
+        color: #f3f3f3;
+      }
+      .panel {
+        display: grid;
+        gap: 8px;
+        text-align: center;
+      }
+      .spinner {
+        width: 28px;
+        height: 28px;
+        margin: 0 auto 8px;
+        border: 3px solid #333;
+        border-top-color: #4caf50;
+        border-radius: 50%;
+        animation: spin 900ms linear infinite;
+      }
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+      .subtitle {
+        opacity: 0.75;
+        font-size: 0.9rem;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="panel">
+      <div class="spinner" aria-hidden="true"></div>
+      <strong>Starting sing-attune…</strong>
+      <span class="subtitle">Launching backend service</span>
+    </div>
+  </body>
+</html>


### PR DESCRIPTION
### Motivation
- Provide a desktop Electron shell that launches the FastAPI backend automatically so the app can be started without a terminal.
- Choose a dynamic localhost port and surface it to the renderer so packaged backends avoid port conflicts.
- Ensure robust lifecycle handling: wait for backend health, show splash during startup, auto-restart on crash, and terminate backend cleanly on quit.

### Description
- Add `electron/main.js` implementing backend executable discovery, dynamic port selection, child-process spawn with `SING_ATTUNE_BACKEND_PORT`, `/health` polling, crash auto-restart, and graceful shutdown (SIGTERM → SIGKILL). 
- Add `electron/preload.js` exposing `getBackendPort()` and `getBackendConfig()` via a secure `contextBridge` and pass the port to the renderer via `additionalArguments`.
- Add `electron/splash.html` and `electron/package.json` to provide a startup splash screen and a minimal Electron scaffold for development.
- Update `README.md` project status and structure to include the new `electron/` bootstrap work; this PR closes the linked issue. 

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded.
- Ran `node --check electron/main.js && node --check electron/preload.js`, which succeeded with no syntax errors.
- Ran `uv run pytest -v`, which failed during collection in this environment due to missing system deps (`PortAudio`) and `torch` (errors during test collection), so full backend tests could not complete here.
- Attempted a Playwright screenshot of the splash page but the local HTTP serving step failed in the container (`ERR_EMPTY_RESPONSE`), so visual verification was not completed.

Closes #18

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f23ba33c8327a0e77ada5dcd6b73)