### PR TITLE
feat: configure electron-builder to bundle local soundfont assets

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -4,9 +4,33 @@
   "private": true,
   "main": "main.js",
   "scripts": {
-    "start": "electron ."
+    "start": "electron .",
+    "dist": "electron-builder"
   },
   "devDependencies": {
-    "electron": "^31.0.2"
+    "electron": "^31.0.2",
+    "electron-builder": "^24.13.3"
+  },
+  "build": {
+    "appId": "com.singattune.app",
+    "files": [
+      "main.js",
+      "preload.js",
+      "splash.html",
+      "package.json"
+    ],
+    "extraResources": [
+      {
+        "from": "../frontend/public/soundfonts",
+        "to": "soundfonts",
+        "filter": [
+          "**/*"
+        ]
+      },
+      {
+        "from": "../NOTICE",
+        "to": "NOTICE"
+      }
+    ]
   }
 }


### PR DESCRIPTION
### Motivation
- Ensure packaged Electron builds include the FluidR3 soundfont so offline playback does not fetch from a CDN.
- Include the repository `NOTICE` file in packaged resources for licensing/attribution.
- Add an explicit `electron-builder` configuration because `electron/package.json` previously had no `build` section.

### Description
- Update `electron/package.json` to add `electron-builder` as a dev dependency and a `dist` script that runs `electron-builder`.
- Add a `build` section that lists app entry files and configures `extraResources` to copy `../frontend/public/soundfonts/**` into the packaged `soundfonts` directory and include `../NOTICE` into the installer.
- This change only affects packaging metadata and does not modify runtime code paths. Closes #242

### Testing
- Ran linter checks with `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded.
- Ran the test suite with `uv run pytest -v`; collection failed due to missing PortAudio and `torch` in the environment, which are unrelated to this packaging-only change and are expected in this CI-free environment.
- No packaged build was produced here; the `dist` script (`electron-builder`) can be used locally or in CI to validate that `/soundfonts/FluidR3_GM/acoustic_grand_piano-mp3.js` and `NOTICE` are present in the final application bundle.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b744c2493c8327b826c126d6b46141)