### PR TITLE
docs: add demo notice and known limitations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 
 sing-attune plays your part from a MusicXML score through your headphones. You sing along. As you sing, your pitch appears live on the score — a moving dot over the notation, green when you're on it, red when you're not. No post-hoc analysis, no percentage scores. Just an honest mirror of what your voice is doing, in the moment, against what the music asks for.
 
+## Demo
+
+Demo GIF is shared in the PR/release notes (kept out of the repository to avoid committing binary assets).
+
 ---
 
 ## The loop
@@ -88,6 +92,14 @@ This keeps the backend real-time pipeline simple while score-aware interpretatio
 | Real-time pitch overlay | ✅ Done (Day 10) |
 | Transport controls | 🔲 Day 11 |
 | Electron packaging | 🔲 Day 16 |
+
+---
+
+## Known limitations (v1.0)
+
+- **Polyphony is not supported** — pitch tracking assumes one singing voice at a time.
+- **Melisma alignment is approximate** — long syllables spanning many notes can produce ambiguous note matching.
+- **Falsetto / airy phonation can confuse CREPE** — confidence may drop and cause gaps in the visible pitch trace.
 
 ---
 


### PR DESCRIPTION
### Motivation

- Clarify where the demo asset is located and avoid committing binary GIFs into the repository by noting the demo is shared in the PR/release notes. 
- Surface important v1.0 limitations to set user expectations about pitch tracking and alignment behavior.

### Description

- Update `README.md` with a new `## Demo` section explaining the demo GIF is kept out of the repo and shared in the PR/release notes. 
- Add a `## Known limitations (v1.0)` section listing polyphony, melisma alignment, and falsetto/airy phonation caveats. 
- Apply minor formatting and spacing adjustments around the new sections in `README.md`.

### Testing

- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b6f2786e5c832789b1f21579104d27)