### PR TITLE
feat: add release packaging workflow

### DIFF
--- a/.github/workflows/package-on-release.yml
+++ b/.github/workflows/package-on-release.yml
@@ -1,0 +1,91 @@
+name: Package on Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  package:
+    name: Package desktop bundle (Windows)
+    runs-on: windows-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Set up uv
+        uses: astral-sh/setup-uv@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install backend dependencies
+        run: |
+          uv sync
+          uv pip install torch torchaudio --index-url https://download.pytorch.org/whl/cpu
+          uv pip install torchcrepe
+
+      - name: Install frontend dependencies
+        run: npm ci
+        working-directory: frontend
+
+      - name: Run backend lint
+        run: uv run ruff check backend/
+
+      - name: Run backend tests
+        run: uv run pytest backend/tests -v --tb=short
+
+      - name: Run frontend tests
+        run: npm test
+        working-directory: frontend
+
+      - name: Build backend bundle
+        run: uv run pyinstaller --noconfirm backend.spec
+
+      - name: Build desktop package
+        run: npm run package:win
+        working-directory: frontend
+
+      - name: Rename artifact and generate checksums
+        shell: pwsh
+        run: |
+          New-Item -ItemType Directory -Force -Path release | Out-Null
+          $zip = Get-ChildItem -Path release -Filter '*.zip' | Select-Object -First 1
+          if (-not $zip) {
+            throw 'No zip artifact was produced in release/'
+          }
+
+          $tag = "${{ github.ref_name }}"
+          $renamed = "sing-attune-$tag-windows-x64.zip"
+          Move-Item -Path $zip.FullName -Destination (Join-Path $zip.DirectoryName $renamed) -Force
+
+          $hash = Get-FileHash -Algorithm SHA256 (Join-Path $zip.DirectoryName $renamed)
+          "$($hash.Hash)  $renamed" | Out-File -FilePath (Join-Path $zip.DirectoryName 'SHA256SUMS.txt') -Encoding ascii
+
+      - name: Upload workflow artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: sing-attune-${{ github.ref_name }}-windows-x64
+          path: |
+            release/sing-attune-${{ github.ref_name }}-windows-x64.zip
+            release/SHA256SUMS.txt
+          if-no-files-found: error
+          retention-days: 30
+
+      - name: Attach artifacts to release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            release/sing-attune-${{ github.ref_name }}-windows-x64.zip
+            release/SHA256SUMS.txt

--- a/README.md
+++ b/README.md
@@ -250,6 +250,9 @@ Every pull request runs:
 - **Codecov** — coverage delta reported on every PR
 - **Claude AI review** — reviews the diff against the linked issue's acceptance criteria
 
+Every published GitHub release runs:
+- **package-on-release** — Windows packaging pipeline that lints/tests, builds the backend with PyInstaller, packages the Electron app, uploads artifacts to the workflow run, and attaches the ZIP + `SHA256SUMS.txt` to the Release page.
+
 Run locally before pushing:
 
 Backend (lint + tests):


### PR DESCRIPTION
### Motivation
- Provide an automated, repeatable packaging pipeline that runs when a GitHub release is published so maintainers receive downloadable release artifacts without manual steps.
- Produce a Windows installer ZIP (Electron + PyInstaller backend) and attach it to the Release page with a checksum to make releases consistent and verifiable.

### Description
- Add `.github/workflows/package-on-release.yml`, a `release.published`-triggered workflow that sets up Python/`uv`, Node.js, installs dependencies, runs backend lint/tests and frontend tests, builds the PyInstaller backend bundle and the Electron Windows ZIP, renames the artifact to include the release tag, generates `SHA256SUMS.txt`, uploads workflow artifacts, and attaches them to the GitHub Release.
- Update `README.md` to document the new `package-on-release` workflow and its outputs.
- Workflow targets `windows-latest` and uses `astral-sh/setup-uv`, `actions/setup-python`, `actions/setup-node`, `actions/upload-artifact@v4`, and `softprops/action-gh-release@v2` to attach artifacts to the Release.
- Closes #253

### Testing
- Ran `uv run ruff check backend/ --fix` which completed successfully and then `uv run ruff check backend/` which passed.
- Initial `uv run pytest -v` failed due to missing PortAudio and missing `torch` in the environment (automated failure reported during collection), so `libportaudio2` and required Python packages were installed and retried.
- After installing `libportaudio2` and the Python packages (`torch`, `torchaudio`, `torchcrepe`) the full test suite `uv run pytest -v` passed with `163 passed, 35 skipped` and the `GITHUB_ACTIONS=1 uv run pytest -v` run also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b7f02b52c483279bec1205ff6772c7)