### PR TITLE
feat: add shared transcription domain models

### DIFF
--- a/backend/audio/pitch.py
+++ b/backend/audio/pitch.py
@@ -23,6 +23,8 @@ from dataclasses import dataclass
 from enum import Enum, auto
 from typing import Callable
 
+from backend.models.transcription import PitchFrame
+
 import numpy as np
 
 try:
@@ -102,29 +104,6 @@ def select_engine() -> Engine:
     torchcrepe on CPU is ~200ms/frame — too slow for real-time; fall back to pYIN.
     """
     return resolve_engine_runtime().engine
-
-
-# ── Data types ─────────────────────────────────────────────────────────────────
-
-
-@dataclass(frozen=True)
-class PitchFrame:
-    """
-    Single pitch detection result.
-
-    midi: float MIDI note number preserving cent detail.
-          e.g. 60.3 = C4 + 30 cents, 60.0 = C4 exactly.
-    """
-    time_ms: float
-    midi: float
-    confidence: float
-
-    def to_dict(self) -> dict:
-        return {
-            "time_ms": self.time_ms,
-            "midi": self.midi,
-            "confidence": self.confidence,
-        }
 
 
 # ── Conversion helpers ─────────────────────────────────────────────────────────

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,0 +1,17 @@
+"""Shared backend models."""
+
+from .transcription import (
+    NoteEvent,
+    PitchFrame,
+    RestEvent,
+    TranscriptionOptions,
+    TranscriptionSummary,
+)
+
+__all__ = [
+    "PitchFrame",
+    "NoteEvent",
+    "RestEvent",
+    "TranscriptionOptions",
+    "TranscriptionSummary",
+]

--- a/backend/models/transcription.py
+++ b/backend/models/transcription.py
@@ -1,0 +1,64 @@
+"""Shared acoustic-domain models for transcription pipeline data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PitchFrame:
+    """Single pitch detection frame emitted by the analysis engine."""
+
+    time_ms: float
+    midi: float
+    confidence: float
+
+    def to_dict(self) -> dict[str, float]:
+        return {
+            "time_ms": self.time_ms,
+            "midi": self.midi,
+            "confidence": self.confidence,
+        }
+
+
+@dataclass(frozen=True)
+class NoteEvent:
+    """Detected monophonic note event before notation quantization."""
+
+    start_time: float
+    end_time: float
+    pitch: float
+    confidence: float
+
+    @property
+    def duration_seconds(self) -> float:
+        return max(0.0, self.end_time - self.start_time)
+
+
+@dataclass(frozen=True)
+class RestEvent:
+    """Detected silence event before notation quantization."""
+
+    start_time: float
+    end_time: float
+
+    @property
+    def duration_seconds(self) -> float:
+        return max(0.0, self.end_time - self.start_time)
+
+
+@dataclass(frozen=True)
+class TranscriptionOptions:
+    """Optional user-provided hints used during transcription."""
+
+    tempo_bpm: float | None = None
+    time_signature: str | None = None
+
+
+@dataclass(frozen=True)
+class TranscriptionSummary:
+    """Summary statistics describing a transcription run."""
+
+    note_count: int
+    duration_seconds: float
+    average_confidence: float

--- a/backend/tests/test_transcription_models.py
+++ b/backend/tests/test_transcription_models.py
@@ -1,0 +1,55 @@
+"""Tests for shared transcription domain models."""
+
+import pytest
+
+from backend.models.transcription import (
+    NoteEvent,
+    PitchFrame,
+    RestEvent,
+    TranscriptionOptions,
+    TranscriptionSummary,
+)
+
+
+class TestPitchFrame:
+    def test_to_dict(self):
+        frame = PitchFrame(time_ms=125.0, midi=60.3, confidence=0.92)
+        assert frame.to_dict() == {"time_ms": 125.0, "midi": 60.3, "confidence": 0.92}
+
+    def test_immutable(self):
+        frame = PitchFrame(time_ms=0.0, midi=69.0, confidence=0.8)
+        with pytest.raises((AttributeError, TypeError)):
+            frame.midi = 70.0  # type: ignore[misc]
+
+
+class TestNoteEvent:
+    def test_duration_seconds(self):
+        event = NoteEvent(start_time=1.25, end_time=2.0, pitch=440.0, confidence=0.95)
+        assert event.duration_seconds == 0.75
+
+    def test_duration_clamps_negative(self):
+        event = NoteEvent(start_time=2.0, end_time=1.25, pitch=440.0, confidence=0.95)
+        assert event.duration_seconds == 0.0
+
+
+class TestRestEvent:
+    def test_duration_seconds(self):
+        event = RestEvent(start_time=3.0, end_time=3.5)
+        assert event.duration_seconds == 0.5
+
+
+class TestTranscriptionMetadata:
+    def test_options_defaults(self):
+        options = TranscriptionOptions()
+        assert options.tempo_bpm is None
+        assert options.time_signature is None
+
+    def test_summary_fields(self):
+        summary = TranscriptionSummary(
+            note_count=12,
+            duration_seconds=8.4,
+            average_confidence=0.86,
+        )
+        assert summary.note_count == 12
+        assert summary.duration_seconds == 8.4
+        assert summary.average_confidence == 0.86


### PR DESCRIPTION
### Motivation

- Provide a single, stable set of acoustic-domain types used across the transcription pipeline to reduce coupling between analysis, quantization, export, and API layers.
- Prepare shared models that downstream features (#266, #259, #260) can consume without importing notation/export code.

### Description

- Add `backend/models/transcription.py` defining `PitchFrame`, `NoteEvent`, `RestEvent`, `TranscriptionOptions`, and `TranscriptionSummary` with serde and duration helpers.
- Expose the models via `backend/models/__init__.py` so other modules can import a single package surface.
- Update `backend/audio/pitch.py` to import and use the shared `PitchFrame` type instead of a local definition.
- Add unit tests `backend/tests/test_transcription_models.py` covering immutability, `to_dict`, duration behavior, and metadata defaults.

Closes #265

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both completed with no violations.
- Ran `uv run pytest -v backend/tests/test_transcription_models.py`, and all tests passed (7 passed).
- Ran `uv run pytest -v` for full test suite, which failed during collection in this environment due to missing system dependencies (`PortAudio`) and missing `torch`, unrelated to these model changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b86459914c8327bd58c77483756486)