### PR TITLE
Pitch Extraction #266

### DIFF
--- a/backend/audio/pitch_track.py
+++ b/backend/audio/pitch_track.py
@@ -70,6 +70,9 @@ def extract_pitch_frames(audio: np.ndarray, config: PitchTrackConfig) -> list[Pi
     if len(audio) == 0:
         return []
 
+    if len(audio) < config.frame_length:
+        return [PitchFrame(time_ms=0.0, midi=0.0, confidence=0.0)]
+
     f0_hz, voiced_flag, voiced_prob = librosa.pyin(
         audio.astype(np.float32, copy=False),
         fmin=config.fmin_hz,
@@ -109,7 +112,7 @@ def extract_pitch_frames(audio: np.ndarray, config: PitchTrackConfig) -> list[Pi
             corrected_midis[idx] = _closest_octave(midi, reference_midi)
 
     frames: list[PitchFrame] = []
-    for time_ms, midi, confidence in zip(frame_times_ms, corrected_midis, confidences, strict=False):
+    for time_ms, midi, confidence in zip(frame_times_ms, corrected_midis, confidences, strict=True):
         frames.append(PitchFrame(time_ms=time_ms, midi=midi, confidence=confidence))
 
     return frames

--- a/backend/tests/test_pitch_track.py
+++ b/backend/tests/test_pitch_track.py
@@ -25,6 +25,17 @@ class TestExtractPitchFrames:
         config = PitchTrackConfig(sample_rate=22050)
         assert extract_pitch_frames(np.array([], dtype=np.float32), config) == []
 
+    def test_sub_frame_audio_returns_single_unvoiced_frame(self):
+        config = PitchTrackConfig(sample_rate=22050, hop_length=256, frame_length=2048)
+        audio = np.zeros(1024, dtype=np.float32)
+
+        frames = extract_pitch_frames(audio, config)
+
+        assert len(frames) == 1
+        assert frames[0].time_ms == 0.0
+        assert frames[0].midi == 0.0
+        assert frames[0].confidence == 0.0
+
     def test_sustained_a4_is_stable(self):
         config = PitchTrackConfig(sample_rate=22050, hop_length=256, frame_length=2048)
         frames = extract_pitch_frames(_sine(440.0, 1.5, 22050), config)


### PR DESCRIPTION
Description
Extract pitch frames from audio recordings.

This issue implements the reusable offline pitch extraction layer for monophonic vocal transcription.

Implementation
Module

backend/audio/pitch_track.py
Responsibilities

detect pitch over time
detect voiced and unvoiced regions
produce time-aligned pitch frames
emit confidence values per frame
Output structure

class PitchFrame:
    time: float
    frequency: float
    confidence: float
Acceptance Criteria
stable pitch detection on sustained notes
minimal octave errors
silence detected correctly
output is reusable by downstream segmentation logic

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b94594fb3883279e99016b7819278b)

Closes #266 