### PR TITLE
feat: add MusicXML export layer

### DIFF
--- a/backend/music/__init__.py
+++ b/backend/music/__init__.py
@@ -6,6 +6,13 @@ from .notation_policy import (
     NotationPolicy,
     V1_NOTATION_POLICY,
 )
+from .musicxml_export import (
+    MusicXMLExportError,
+    score_model_to_music21_score,
+    score_model_to_musicxml_bytes,
+    score_model_to_musicxml_string,
+    write_score_model_musicxml,
+)
 from .score_model import (
     LyricSyllabic,
     Measure,
@@ -18,6 +25,11 @@ from .score_model import (
 )
 
 __all__ = [
+    "MusicXMLExportError",
+    "score_model_to_music21_score",
+    "score_model_to_musicxml_bytes",
+    "score_model_to_musicxml_string",
+    "write_score_model_musicxml",
     "LyricSyllabic",
     "Measure",
     "NoteScoreEvent",

--- a/backend/music/musicxml_export.py
+++ b/backend/music/musicxml_export.py
@@ -1,0 +1,124 @@
+"""MusicXML export adapter for the internal notation-domain score model."""
+
+from __future__ import annotations
+
+from fractions import Fraction
+from pathlib import Path
+from typing import Final
+
+from music21 import clef, key, layout, metadata, meter, note, stream, tempo, tie
+from music21.musicxml import m21ToXml
+
+from .score_model import LyricSyllabic, NoteScoreEvent, RestScoreEvent, ScoreModel
+
+DEFAULT_DIVISIONS: Final[int] = 4
+SUPPORTED_LYRIC_SYLLABICS: Final[set[str]] = {member.value for member in LyricSyllabic}
+
+
+class MusicXMLExportError(ValueError):
+    """Raised when a score model cannot be represented as valid MusicXML."""
+
+
+def score_model_to_music21_score(score_model: ScoreModel) -> stream.Score:
+    """Convert a notation-domain ``ScoreModel`` into a ``music21`` score."""
+
+    score = stream.Score(id="sing-attune-score")
+    score.metadata = metadata.Metadata()
+    score.metadata.title = "sing-attune export"
+
+    part = stream.Part(id="P1")
+    part.partName = "Voice"
+    part.append(clef.TrebleClef())
+
+    if score_model.metadata.tempo_bpm is not None:
+        part.append(tempo.MetronomeMark(number=score_model.metadata.tempo_bpm))
+
+    part.append(meter.TimeSignature(score_model.metadata.time_signature))
+
+    if score_model.metadata.key_signature is not None:
+        part.append(_build_key_signature(score_model.metadata.key_signature))
+
+    part.append(layout.StaffLayout(staffLines=5))
+
+    for measure_model in score_model.measures:
+        measure = stream.Measure(number=measure_model.number)
+        for event in measure_model.events:
+            measure.append(_score_event_to_music21(event))
+        part.append(measure)
+
+    score.append(part)
+    return score
+
+
+def score_model_to_musicxml_bytes(score_model: ScoreModel) -> bytes:
+    """Render a ``ScoreModel`` as MusicXML bytes."""
+
+    exporter = m21ToXml.GeneralObjectExporter(score_model_to_music21_score(score_model))
+    return bytes(exporter.parse())
+
+
+def score_model_to_musicxml_string(score_model: ScoreModel) -> str:
+    """Render a ``ScoreModel`` as a UTF-8 MusicXML string."""
+
+    return score_model_to_musicxml_bytes(score_model).decode("utf-8")
+
+
+def write_score_model_musicxml(score_model: ScoreModel, output_path: str | Path) -> Path:
+    """Write a ``ScoreModel`` MusicXML document to disk and return the path."""
+
+    path = Path(output_path)
+    path.write_bytes(score_model_to_musicxml_bytes(score_model))
+    return path
+
+
+def _score_event_to_music21(event: NoteScoreEvent | RestScoreEvent) -> note.NotRest:
+    if isinstance(event, NoteScoreEvent):
+        rendered_note = note.Note(event.pitch)
+        rendered_note.duration.quarterLength = _quarter_length(event.duration_beats)
+        rendered_note.tie = _build_tie(event.tie_start, event.tie_stop)
+        _attach_lyric(rendered_note, event.lyric_text, event.lyric_syllabic)
+        return rendered_note
+
+    rendered_rest = note.Rest()
+    rendered_rest.duration.quarterLength = _quarter_length(event.duration_beats)
+    return rendered_rest
+
+
+def _quarter_length(duration_beats: float) -> Fraction:
+    return Fraction(str(duration_beats)).limit_denominator(64)
+
+
+def _build_tie(tie_start: bool, tie_stop: bool) -> tie.Tie | None:
+    if tie_start and tie_stop:
+        return tie.Tie("continue")
+    if tie_start:
+        return tie.Tie("start")
+    if tie_stop:
+        return tie.Tie("stop")
+    return None
+
+
+def _attach_lyric(
+    rendered_note: note.Note,
+    lyric_text: str | None,
+    lyric_syllabic: LyricSyllabic | None,
+) -> None:
+    if lyric_text is None:
+        return
+    lyric = note.Lyric(text=lyric_text)
+    if lyric_syllabic is not None:
+        if lyric_syllabic.value not in SUPPORTED_LYRIC_SYLLABICS:
+            raise MusicXMLExportError(f"Unsupported lyric syllabic value: {lyric_syllabic}")
+        lyric.syllabic = lyric_syllabic.value
+    rendered_note.lyrics = [lyric]
+
+
+def _build_key_signature(key_signature: str) -> key.KeySignature:
+    try:
+        if " " in key_signature.strip():
+            parsed_key = key.Key(key_signature)
+            return key.KeySignature(parsed_key.sharps)
+        parsed_key = key.Key(key_signature)
+        return key.KeySignature(parsed_key.sharps)
+    except Exception as exc:  # pragma: no cover - music21 raises varied exception types
+        raise MusicXMLExportError(f"Unsupported key signature: {key_signature}") from exc

--- a/backend/tests/test_musicxml_export.py
+++ b/backend/tests/test_musicxml_export.py
@@ -1,0 +1,187 @@
+"""Tests for MusicXML export from the internal score model."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from music21 import converter, note, stream
+
+from backend.music.musicxml_export import (
+    MusicXMLExportError,
+    score_model_to_music21_score,
+    score_model_to_musicxml_string,
+    write_score_model_musicxml,
+)
+from backend.music.score_model import (
+    LyricSyllabic,
+    Measure,
+    NoteScoreEvent,
+    RestScoreEvent,
+    ScoreMetadata,
+    ScoreModel,
+)
+
+
+class TestMusicXMLExport:
+    def test_converts_score_model_to_music21_score(self):
+        model = ScoreModel(
+            metadata=ScoreMetadata(tempo_bpm=92, key_signature="D", time_signature="3/4"),
+            measures=[
+                Measure(
+                    number=1,
+                    events=[
+                        NoteScoreEvent(
+                            pitch="C4",
+                            duration_beats=1.0,
+                            source_start_time=0.0,
+                            source_end_time=0.5,
+                            lyric_text="Hal",
+                            lyric_syllabic=LyricSyllabic.BEGIN,
+                        ),
+                        NoteScoreEvent(
+                            pitch="C4",
+                            duration_beats=0.5,
+                            source_start_time=0.5,
+                            source_end_time=0.75,
+                            tie_start=True,
+                        ),
+                        RestScoreEvent(
+                            duration_beats=1.5,
+                            source_start_time=0.75,
+                            source_end_time=1.5,
+                        ),
+                    ],
+                ),
+                Measure(
+                    number=2,
+                    events=[
+                        NoteScoreEvent(
+                            pitch="C4",
+                            duration_beats=0.5,
+                            source_start_time=1.5,
+                            source_end_time=1.75,
+                            tie_stop=True,
+                            lyric_text="lo",
+                            lyric_syllabic=LyricSyllabic.END,
+                        ),
+                        NoteScoreEvent(
+                            pitch="E4",
+                            duration_beats=2.5,
+                            source_start_time=1.75,
+                            source_end_time=3.0,
+                            confidence=0.95,
+                        ),
+                    ],
+                ),
+            ],
+        )
+
+        exported_score = score_model_to_music21_score(model)
+
+        part = exported_score.parts[0]
+        measures = part.getElementsByClass(stream.Measure)
+        assert len(measures) == 2
+        assert measures[0].number == 1
+        assert measures[1].number == 2
+
+        first_measure_notes = measures[0].notesAndRests
+        assert first_measure_notes[0].quarterLength == 1.0
+        assert first_measure_notes[0].lyric == "Hal"
+        assert first_measure_notes[0].lyrics[0].syllabic == "begin"
+        assert first_measure_notes[1].tie.type == "start"
+        assert first_measure_notes[2].isRest
+
+        second_measure_notes = measures[1].notesAndRests
+        assert second_measure_notes[0].tie.type == "stop"
+        assert second_measure_notes[0].lyrics[0].syllabic == "end"
+        assert second_measure_notes[1].quarterLength == 2.5
+
+    def test_renders_musicxml_that_round_trips_through_music21(self):
+        model = ScoreModel(
+            metadata=ScoreMetadata(tempo_bpm=88, key_signature="Bb", time_signature="4/4"),
+            measures=[
+                Measure(
+                    number=1,
+                    events=[
+                        NoteScoreEvent(
+                            pitch="D4",
+                            duration_beats=1.0,
+                            source_start_time=0.0,
+                            source_end_time=0.5,
+                            lyric_text="Twin",
+                            lyric_syllabic=LyricSyllabic.SINGLE,
+                        ),
+                        RestScoreEvent(
+                            duration_beats=1.0,
+                            source_start_time=0.5,
+                            source_end_time=1.0,
+                        ),
+                        NoteScoreEvent(
+                            pitch="F4",
+                            duration_beats=2.0,
+                            source_start_time=1.0,
+                            source_end_time=2.0,
+                        ),
+                    ],
+                )
+            ],
+        )
+
+        musicxml = score_model_to_musicxml_string(model)
+
+        assert "<time>" in musicxml
+        assert "<beats>4</beats>" in musicxml
+        assert "<beat-type>4</beat-type>" in musicxml
+        assert "<rest" in musicxml
+        assert "<lyric" in musicxml
+        assert "<syllabic>single</syllabic>" in musicxml
+
+        parsed = converter.parseData(musicxml)
+        parsed_notes = list(parsed.recurse().getElementsByClass(note.Note))
+        assert parsed_notes[0].lyric == "Twin"
+        assert parsed_notes[0].lyrics[0].syllabic == "single"
+
+    def test_writes_musicxml_file(self, tmp_path: Path):
+        model = ScoreModel(
+            metadata=ScoreMetadata(),
+            measures=[
+                Measure(
+                    number=1,
+                    events=[
+                        NoteScoreEvent(
+                            pitch="C4",
+                            duration_beats=4.0,
+                            source_start_time=0.0,
+                            source_end_time=2.0,
+                        )
+                    ],
+                )
+            ],
+        )
+
+        output_path = write_score_model_musicxml(model, tmp_path / "export.musicxml")
+
+        assert output_path.exists()
+        assert output_path.read_text(encoding="utf-8").startswith("<?xml")
+
+    def test_rejects_unsupported_key_signature(self):
+        model = ScoreModel(
+            metadata=ScoreMetadata(key_signature="definitely-not-a-key"),
+            measures=[
+                Measure(
+                    number=1,
+                    events=[
+                        NoteScoreEvent(
+                            pitch="C4",
+                            duration_beats=4.0,
+                            source_start_time=0.0,
+                            source_end_time=1.0,
+                        )
+                    ],
+                )
+            ],
+        )
+
+        with pytest.raises(MusicXMLExportError, match="Unsupported key signature"):
+            score_model_to_music21_score(model)


### PR DESCRIPTION
### Motivation
- Provide an export adapter that converts the internal `ScoreModel` into MusicXML so transcriptions can be saved and opened in notation editors. 
- Keep `music21` usage isolated to the export layer and support notation-domain features required by v1 (measures, rests, ties, tempo/time/key metadata, and manual lyrics). 

### Description
- Add `backend/music/musicxml_export.py` implementing `score_model_to_music21_score`, `score_model_to_musicxml_bytes`, `score_model_to_musicxml_string`, and `write_score_model_musicxml`, plus helpers for ties, lyric syllabics, and key-signature mapping. 
- Expose the new export API and `MusicXMLExportError` from `backend.music` so callers can use the exporter without importing `music21` directly. 
- Add tests in `backend/tests/test_musicxml_export.py` covering score->music21 conversion, lyric/tie/rest handling, MusicXML round-trip via `music21`, file writing, and unsupported key signature rejection. 
- Closes #262

### Testing
- Ran linter fixes with `uv run ruff check backend/ --fix` and verified `uv run ruff check backend/` — all checks passed. 
- Ran the focused tests with `uv run pytest backend/tests/test_musicxml_export.py -v` and the new tests passed (4 passed). 
- Ran the full CI-style test run with `GITHUB_ACTIONS=1 uv run pytest -v` and observed `212 passed, 35 skipped` (no failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bab5131dac83279d3e526aa4ca704a)