### PR TITLE
fix: rerun PR workflow coverage on PR updates

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,8 +1,9 @@
 name: PR Review
 
 on:
+  # Run the PR validation workflow, including the Codecov upload, on every PR update
+  # so new commits pushed to an open PR always refresh coverage.
   pull_request:
-    types: [opened, synchronize, reopened]
 
 jobs:
   lint:


### PR DESCRIPTION
### Motivation
- Ensure the PR validation workflow (including the pytest coverage run and Codecov upload) runs whenever new commits are pushed to an open pull request so coverage deltas stay up to date.

### Description
- Broadened the trigger in `.github/workflows/pr-review.yml` by removing the restrictive `pull_request.types` list so the workflow runs on every pull request update and Codecov uploads are refreshed; Closes #279.

### Testing
- Ran `uv run ruff check backend/ --fix`, `uv run ruff check backend/`, and `uv run pytest -v`, and linting plus the automated test suite completed successfully (`276 passed, 35 skipped`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb1c379ef08327bdef653df1b9f08d)