### PR TITLE
feat: expose transcription workflow in frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -298,6 +298,55 @@
       background: #122542;
     }
     .mixer-panel.hidden { display: none; }
+
+    #transcription-panel {
+      border: 1px solid #1a5276;
+      border-radius: 6px;
+      padding: 8px;
+      display: flex;
+      flex-direction: column;
+      gap: 8px;
+      background: #122542;
+    }
+    .transcription-header {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 8px;
+      font-size: 0.78rem;
+      color: #dce7ff;
+    }
+    #transcription-status { color: #a8b7cf; }
+    #transcription-file-input {
+      width: 100%;
+      font-size: 0.78rem;
+      color: var(--color-text-muted);
+    }
+    .transcription-meta, .transcription-error, .transcription-empty, .transcription-segments {
+      font-size: 0.75rem;
+      color: #b9cceb;
+    }
+    .transcription-error { color: #ffb4c2; display: none; }
+    .transcription-error.visible { display: block; }
+    .transcription-actions { display: flex; gap: 8px; }
+    .transcription-result.hidden { display: none; }
+    .transcription-summary {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 6px 10px;
+      font-size: 0.76rem;
+      color: #dce7ff;
+      margin-bottom: 8px;
+    }
+    .transcription-detail-block { margin-top: 8px; }
+    .transcription-detail-block h4 { font-size: 0.76rem; margin-bottom: 6px; color: #dce7ff; }
+    .transcription-table { width: 100%; border-collapse: collapse; font-size: 0.74rem; }
+    .transcription-table th, .transcription-table td {
+      text-align: left;
+      border-bottom: 1px solid rgba(26, 82, 118, 0.7);
+      padding: 4px 2px;
+    }
+    #transcription-download.disabled { opacity: 0.45; pointer-events: none; }
     .mixer-panel label {
       display: flex;
       justify-content: space-between;
@@ -823,6 +872,7 @@
       <div id="slot-pitch-overlay" class="feature-slot"></div>
       <div id="slot-audio-preflight" class="feature-slot"></div>
       <div id="slot-progress-history" class="feature-slot"></div>
+      <div id="slot-transcription" class="feature-slot"></div>
     </div>
 
   </div>

--- a/frontend/src/features/transcription/index.test.ts
+++ b/frontend/src/features/transcription/index.test.ts
@@ -1,0 +1,89 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setAppStatusMock = vi.fn();
+const showErrorBannerMock = vi.fn();
+const clearErrorBannerMock = vi.fn();
+const requestTranscriptionMock = vi.fn();
+const createObjectUrlMock = vi.fn(() => 'blob:musicxml');
+
+vi.mock('../../services/status', () => ({
+  setAppStatus: (...args: unknown[]) => setAppStatusMock(...args),
+}));
+
+vi.mock('../../services/backend', () => ({
+  showErrorBanner: (...args: unknown[]) => showErrorBannerMock(...args),
+  clearErrorBanner: () => clearErrorBannerMock(),
+}));
+
+vi.mock('./transcription-api', async () => {
+  const actual = await vi.importActual<typeof import('./transcription-api')>('./transcription-api');
+  return {
+    ...actual,
+    requestTranscription: (...args: unknown[]) => requestTranscriptionMock(...args),
+  };
+});
+
+import { transcriptionFeature } from './index';
+
+function installDom(): void {
+  document.body.innerHTML = [
+    '<div id="slot-transcription"></div>',
+    '<div id="error-banner"><span id="error-banner-message"></span><button id="error-banner-action" class="hidden"></button><button id="error-banner-dismiss" class="hidden"></button></div>',
+  ].join('');
+}
+
+describe('transcriptionFeature', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+    installDom();
+    vi.stubGlobal('URL', {
+      createObjectURL: createObjectUrlMock,
+      revokeObjectURL: vi.fn(),
+    });
+  });
+
+  it('renders parsed results after a successful transcription', async () => {
+    requestTranscriptionMock.mockResolvedValue({
+      musicxml: `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0"><part id="P1"><measure number="1"><attributes><divisions>1</divisions></attributes><note><pitch><step>C</step><octave>4</octave></pitch><duration>1</duration></note></measure></part></score-partwise>`,
+      tempoBpm: 120,
+      keySignature: 'C major',
+    });
+
+    const slot = document.getElementById('slot-transcription') as HTMLDivElement;
+    transcriptionFeature.mount(slot);
+
+    const input = document.getElementById('transcription-file-input') as HTMLInputElement;
+    const file = new File(['wave'], 'take.wav', { type: 'audio/wav' });
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    input.dispatchEvent(new Event('change'));
+
+    const runBtn = document.getElementById('btn-transcription-run') as HTMLButtonElement;
+    runBtn.click();
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(requestTranscriptionMock).toHaveBeenCalledWith(file);
+    expect(setAppStatusMock).toHaveBeenLastCalledWith('transcription ready', 'success');
+    expect(document.getElementById('transcription-result')?.classList.contains('hidden')).toBe(false);
+    expect(document.getElementById('transcription-summary')?.textContent).toContain('Notes: 1');
+    expect(createObjectUrlMock).toHaveBeenCalledTimes(1);
+    expect((document.getElementById('transcription-download') as HTMLAnchorElement).download).toBe('transcription.musicxml');
+  });
+
+  it('shows a validation error for unsupported files before calling the backend', () => {
+    const slot = document.getElementById('slot-transcription') as HTMLDivElement;
+    transcriptionFeature.mount(slot);
+
+    const input = document.getElementById('transcription-file-input') as HTMLInputElement;
+    const file = new File(['data'], 'take.txt', { type: 'text/plain' });
+    Object.defineProperty(input, 'files', { value: [file], configurable: true });
+    input.dispatchEvent(new Event('change'));
+
+    const runBtn = document.getElementById('btn-transcription-run') as HTMLButtonElement;
+    runBtn.click();
+
+    expect(requestTranscriptionMock).not.toHaveBeenCalled();
+    expect(showErrorBannerMock).toHaveBeenCalled();
+    expect(document.getElementById('transcription-inline-error')?.textContent).toContain('Unsupported file type');
+  });
+});

--- a/frontend/src/features/transcription/index.ts
+++ b/frontend/src/features/transcription/index.ts
@@ -1,0 +1,234 @@
+import { type Feature } from '../../feature-types';
+import { clearErrorBanner, showErrorBanner } from '../../services/backend';
+import { setAppStatus } from '../../services/status';
+import {
+  parseMusicXmlSummary,
+  requestTranscription,
+  type ParsedTranscriptionSummary,
+} from './transcription-api';
+
+const ACCEPTED_EXTENSIONS = ['.wav', '.wave', '.mp3'];
+const MAX_FILE_SIZE_BYTES = 25 * 1024 * 1024;
+
+let retryLatest: (() => void) | null = null;
+let currentObjectUrl: string | null = null;
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatSeconds(seconds: number): string {
+  return `${seconds.toFixed(2)}s`;
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#39;');
+}
+
+function validateAudioFile(file: File): string | null {
+  const lowerName = file.name.toLowerCase();
+  const hasSupportedExtension = ACCEPTED_EXTENSIONS.some((extension) => lowerName.endsWith(extension));
+  if (!hasSupportedExtension) {
+    return `Unsupported file type. Choose ${ACCEPTED_EXTENSIONS.join(', ')}.`;
+  }
+  if (file.size > MAX_FILE_SIZE_BYTES) {
+    return `File is too large. Choose an audio file under ${formatBytes(MAX_FILE_SIZE_BYTES)}.`;
+  }
+  return null;
+}
+
+function updateDownloadLink(linkEl: HTMLAnchorElement, musicxml: string): void {
+  if (currentObjectUrl) {
+    URL.revokeObjectURL(currentObjectUrl);
+  }
+  currentObjectUrl = URL.createObjectURL(
+    new Blob([musicxml], { type: 'application/vnd.recordare.musicxml+xml' }),
+  );
+  linkEl.href = currentObjectUrl;
+  linkEl.download = 'transcription.musicxml';
+  linkEl.removeAttribute('aria-disabled');
+  linkEl.classList.remove('disabled');
+}
+
+function renderResult(summaryEl: HTMLDivElement, detailsEl: HTMLDivElement, result: ParsedTranscriptionSummary): void {
+  const keyText = result.keySignature ?? 'Unknown';
+  summaryEl.innerHTML = `
+    <div><strong>Notes:</strong> ${result.notes.length}</div>
+    <div><strong>Segments:</strong> ${result.segments.length}</div>
+    <div><strong>Tempo:</strong> ${result.tempoBpm ?? 'Unknown'}</div>
+    <div><strong>Key:</strong> ${escapeHtml(keyText)}</div>
+  `;
+
+  const notesMarkup = result.notes.length > 0
+    ? `<table class="transcription-table"><thead><tr><th>Pitch</th><th>Start</th><th>Duration</th></tr></thead><tbody>${result.notes.map((note) => `
+      <tr>
+        <td>${escapeHtml(note.pitch)}</td>
+        <td>${formatSeconds(note.startSeconds)}</td>
+        <td>${formatSeconds(note.durationSeconds)}</td>
+      </tr>
+    `).join('')}</tbody></table>`
+    : '<p class="transcription-empty">No notes found in the MusicXML response.</p>';
+
+  const segmentsMarkup = result.segments.length > 0
+    ? `<ul class="transcription-segments">${result.segments.map((segment, index) => `
+      <li>Segment ${index + 1}: ${formatSeconds(segment.startSeconds)} → ${formatSeconds(segment.endSeconds)} (${segment.noteCount} notes)</li>
+    `).join('')}</ul>`
+    : '<p class="transcription-empty">No segmentation boundaries detected.</p>';
+
+  detailsEl.innerHTML = `
+    <div class="transcription-detail-block">
+      <h4>Detected notes</h4>
+      ${notesMarkup}
+    </div>
+    <div class="transcription-detail-block">
+      <h4>Segmentation boundaries</h4>
+      ${segmentsMarkup}
+    </div>
+  `;
+}
+
+function mount(slot: HTMLElement): void {
+  slot.innerHTML = `
+    <section id="transcription-panel" aria-label="Audio transcription panel">
+      <div class="transcription-header">
+        <strong>Audio transcription</strong>
+        <span id="transcription-status">Idle</span>
+      </div>
+      <input id="transcription-file-input" type="file" accept=".wav,.wave,.mp3,audio/wav,audio/mpeg" />
+      <div id="transcription-file-meta" class="transcription-meta">No audio selected.</div>
+      <div class="transcription-actions">
+        <button id="btn-transcription-run" class="transport-btn" disabled>Transcribe</button>
+        <button id="btn-transcription-retry" class="transport-btn" disabled>Retry</button>
+      </div>
+      <div id="transcription-inline-error" class="transcription-error" aria-live="polite"></div>
+      <div id="transcription-result" class="transcription-result hidden">
+        <div id="transcription-summary" class="transcription-summary"></div>
+        <div id="transcription-details"></div>
+        <a id="transcription-download" class="transport-btn disabled" aria-disabled="true">Download MusicXML</a>
+      </div>
+    </section>
+  `;
+
+  const inputEl = document.getElementById('transcription-file-input') as HTMLInputElement;
+  const fileMetaEl = document.getElementById('transcription-file-meta') as HTMLDivElement;
+  const statusEl = document.getElementById('transcription-status') as HTMLSpanElement;
+  const runBtn = document.getElementById('btn-transcription-run') as HTMLButtonElement;
+  const retryBtn = document.getElementById('btn-transcription-retry') as HTMLButtonElement;
+  const errorEl = document.getElementById('transcription-inline-error') as HTMLDivElement;
+  const resultEl = document.getElementById('transcription-result') as HTMLDivElement;
+  const summaryEl = document.getElementById('transcription-summary') as HTMLDivElement;
+  const detailsEl = document.getElementById('transcription-details') as HTMLDivElement;
+  const downloadEl = document.getElementById('transcription-download') as HTMLAnchorElement;
+
+  let selectedFile: File | null = null;
+
+  const resetDownload = (): void => {
+    downloadEl.removeAttribute('href');
+    downloadEl.classList.add('disabled');
+    downloadEl.setAttribute('aria-disabled', 'true');
+  };
+
+  const setBusy = (busy: boolean, message: string): void => {
+    statusEl.textContent = message;
+    inputEl.disabled = busy;
+    runBtn.disabled = busy || !selectedFile;
+    retryBtn.disabled = busy || retryLatest === null;
+  };
+
+  const setInlineError = (message: string): void => {
+    errorEl.textContent = message;
+    errorEl.classList.toggle('visible', message.length > 0);
+  };
+
+  const syncSelectedFileUi = (): void => {
+    if (!selectedFile) {
+      fileMetaEl.textContent = 'No audio selected.';
+      runBtn.disabled = true;
+      return;
+    }
+    fileMetaEl.textContent = `${selectedFile.name} • ${formatBytes(selectedFile.size)}`;
+    runBtn.disabled = false;
+  };
+
+  const runTranscription = async (): Promise<void> => {
+    if (!selectedFile) return;
+
+    const validationError = validateAudioFile(selectedFile);
+    if (validationError) {
+      setInlineError(validationError);
+      showErrorBanner(validationError, { dismissible: true });
+      resultEl.classList.add('hidden');
+      setAppStatus('transcription validation failed', 'error');
+      return;
+    }
+
+    retryLatest = () => {
+      void runTranscription();
+    };
+    clearErrorBanner();
+    setInlineError('');
+    resetDownload();
+    setBusy(true, 'Transcribing…');
+    setAppStatus(`Transcribing ${selectedFile.name}…`, 'warning');
+
+    try {
+      const response = await requestTranscription(selectedFile);
+      const parsed = parseMusicXmlSummary(response.musicxml, response.tempoBpm, response.keySignature);
+      renderResult(summaryEl, detailsEl, parsed);
+      updateDownloadLink(downloadEl, response.musicxml);
+      resultEl.classList.remove('hidden');
+      setBusy(false, 'Complete');
+      setAppStatus('transcription ready', 'success');
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      setInlineError(message);
+      showErrorBanner(message, {
+        dismissible: true,
+        actionLabel: 'Retry transcription',
+        onAction: () => {
+          retryLatest?.();
+        },
+      });
+      setBusy(false, 'Failed');
+      setAppStatus('transcription failed', 'error');
+      resultEl.classList.add('hidden');
+    }
+  };
+
+  inputEl.addEventListener('change', () => {
+    const [file] = Array.from(inputEl.files ?? []);
+    selectedFile = file ?? null;
+    setInlineError('');
+    resetDownload();
+    resultEl.classList.add('hidden');
+    syncSelectedFileUi();
+  });
+
+  runBtn.addEventListener('click', () => {
+    void runTranscription();
+  });
+  retryBtn.addEventListener('click', () => {
+    retryLatest?.();
+  });
+  downloadEl.addEventListener('click', (event) => {
+    if (!downloadEl.href) {
+      event.preventDefault();
+    }
+  });
+
+  syncSelectedFileUi();
+  resetDownload();
+}
+
+export const transcriptionFeature: Feature = {
+  id: 'slot-transcription',
+  mount,
+};

--- a/frontend/src/features/transcription/transcription-api.test.ts
+++ b/frontend/src/features/transcription/transcription-api.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseMusicXmlSummary } from './transcription-api';
+
+const SAMPLE_MUSICXML = `<?xml version="1.0" encoding="UTF-8"?>
+<score-partwise version="4.0">
+  <part-list>
+    <score-part id="P1"><part-name>Voice</part-name></score-part>
+  </part-list>
+  <part id="P1">
+    <measure number="1">
+      <attributes>
+        <divisions>2</divisions>
+        <key><fifths>0</fifths></key>
+      </attributes>
+      <direction>
+        <direction-type>
+          <metronome><per-minute>96</per-minute></metronome>
+        </direction-type>
+      </direction>
+      <note>
+        <pitch><step>C</step><octave>4</octave></pitch>
+        <duration>2</duration>
+      </note>
+      <note>
+        <pitch><step>D</step><alter>1</alter><octave>4</octave></pitch>
+        <duration>2</duration>
+      </note>
+      <note>
+        <rest />
+        <duration>2</duration>
+      </note>
+      <note>
+        <pitch><step>G</step><octave>4</octave></pitch>
+        <duration>4</duration>
+      </note>
+    </measure>
+  </part>
+</score-partwise>`;
+
+describe('parseMusicXmlSummary', () => {
+  it('extracts notes, segments, tempo, and key from MusicXML', () => {
+    const result = parseMusicXmlSummary(SAMPLE_MUSICXML);
+
+    expect(result.tempoBpm).toBe(96);
+    expect(result.keySignature).toBe('C major');
+    expect(result.notes).toEqual([
+      { pitch: 'C4', startSeconds: 0, durationSeconds: 1 },
+      { pitch: 'D#4', startSeconds: 1, durationSeconds: 1 },
+      { pitch: 'G4', startSeconds: 3, durationSeconds: 2 },
+    ]);
+    expect(result.segments).toEqual([
+      { startSeconds: 0, endSeconds: 2, noteCount: 2 },
+      { startSeconds: 3, endSeconds: 5, noteCount: 1 },
+    ]);
+  });
+});

--- a/frontend/src/features/transcription/transcription-api.ts
+++ b/frontend/src/features/transcription/transcription-api.ts
@@ -1,0 +1,253 @@
+export interface TranscriptionResponse {
+  musicxml: string;
+  tempoBpm: number | null;
+  keySignature: string | null;
+}
+
+export interface ParsedTranscriptionNote {
+  pitch: string;
+  startSeconds: number;
+  durationSeconds: number;
+}
+
+export interface ParsedTranscriptionSegment {
+  startSeconds: number;
+  endSeconds: number;
+  noteCount: number;
+}
+
+export interface ParsedTranscriptionSummary {
+  notes: ParsedTranscriptionNote[];
+  segments: ParsedTranscriptionSegment[];
+  tempoBpm: number | null;
+  keySignature: string | null;
+}
+
+interface PendingTranscriptionResponse {
+  id?: string;
+  result_url?: string;
+  status?: string;
+  musicxml?: string;
+  tempo_bpm?: number | null;
+  key_signature?: string | null;
+}
+
+const DEFAULT_TRANSCRIPTION_ENDPOINT = '/transcribe/audio';
+const DEFAULT_POLL_INTERVAL_MS = 1000;
+const DEFAULT_MAX_POLLS = 30;
+const DIVISIONS_FALLBACK = 1;
+
+function extensionFromFilename(filename: string): string {
+  const lastDot = filename.lastIndexOf('.');
+  return lastDot >= 0 ? filename.slice(lastDot).toLowerCase() : '';
+}
+
+function inferContentType(filename: string): string {
+  const extension = extensionFromFilename(filename);
+  if (extension === '.mp3') return 'audio/mpeg';
+  return 'audio/wav';
+}
+
+async function extractError(response: Response): Promise<string> {
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/json')) {
+    const payload = await response.json() as { detail?: string };
+    return payload.detail ?? `HTTP ${response.status}`;
+  }
+  return (await response.text()) || `HTTP ${response.status}`;
+}
+
+function parseSyncResponse(musicxml: string, headers: Headers): TranscriptionResponse {
+  const tempoHeader = headers.get('x-transcription-tempo-bpm');
+  const keyHeader = headers.get('x-transcription-key-signature');
+  return {
+    musicxml,
+    tempoBpm: tempoHeader ? Number(tempoHeader) : null,
+    keySignature: keyHeader,
+  };
+}
+
+async function pollForResult(resultUrl: string): Promise<TranscriptionResponse> {
+  for (let attempt = 0; attempt < DEFAULT_MAX_POLLS; attempt += 1) {
+    const response = await fetch(resultUrl);
+    if (!response.ok) {
+      throw new Error(await extractError(response));
+    }
+
+    const contentType = response.headers.get('content-type') ?? '';
+    if (contentType.includes('application/vnd.recordare.musicxml+xml') || contentType.includes('application/xml') || contentType.includes('text/xml')) {
+      return parseSyncResponse(await response.text(), response.headers);
+    }
+
+    const payload = await response.json() as PendingTranscriptionResponse;
+    if (payload.musicxml) {
+      return {
+        musicxml: payload.musicxml,
+        tempoBpm: payload.tempo_bpm ?? null,
+        keySignature: payload.key_signature ?? null,
+      };
+    }
+
+    if (payload.status && payload.status !== 'pending') {
+      throw new Error(`Transcription did not complete successfully (status: ${payload.status}).`);
+    }
+
+    await new Promise((resolve) => {
+      window.setTimeout(resolve, DEFAULT_POLL_INTERVAL_MS);
+    });
+  }
+
+  throw new Error('Transcription timed out. Please try again.');
+}
+
+export async function requestTranscription(file: File): Promise<TranscriptionResponse> {
+  const formData = new FormData();
+  formData.append('file', file, file.name);
+
+  const response = await fetch(DEFAULT_TRANSCRIPTION_ENDPOINT, {
+    method: 'POST',
+    body: formData,
+    headers: {
+      Accept: 'application/json, application/vnd.recordare.musicxml+xml, text/xml',
+      'x-upload-content-type': file.type || inferContentType(file.name),
+    },
+  });
+
+  if (!response.ok) {
+    throw new Error(await extractError(response));
+  }
+
+  const contentType = response.headers.get('content-type') ?? '';
+  if (contentType.includes('application/vnd.recordare.musicxml+xml') || contentType.includes('application/xml') || contentType.includes('text/xml')) {
+    return parseSyncResponse(await response.text(), response.headers);
+  }
+
+  const payload = await response.json() as PendingTranscriptionResponse;
+  if (payload.musicxml) {
+    return {
+      musicxml: payload.musicxml,
+      tempoBpm: payload.tempo_bpm ?? null,
+      keySignature: payload.key_signature ?? null,
+    };
+  }
+
+  const resultUrl = payload.result_url ?? (payload.id ? `/result/${payload.id}` : null);
+  if (!resultUrl) {
+    throw new Error('Backend returned an unsupported transcription response.');
+  }
+  return pollForResult(resultUrl);
+}
+
+function pitchNameFromNote(noteEl: Element): string {
+  const step = noteEl.querySelector('pitch > step')?.textContent?.trim() ?? '';
+  const alter = Number(noteEl.querySelector('pitch > alter')?.textContent ?? '0');
+  const octave = noteEl.querySelector('pitch > octave')?.textContent?.trim() ?? '';
+  const accidental = alter === 1 ? '#' : alter === -1 ? 'b' : '';
+  return `${step}${accidental}${octave}`;
+}
+
+function readTempoBpm(xml: Document): number | null {
+  const soundTempo = xml.querySelector('sound[tempo]')?.getAttribute('tempo');
+  if (soundTempo) {
+    const parsed = Number(soundTempo);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  const perMinute = xml.querySelector('direction-type metronome per-minute')?.textContent;
+  if (perMinute) {
+    const parsed = Number(perMinute);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function readKeySignature(xml: Document): string | null {
+  const fifthsText = xml.querySelector('attributes key fifths')?.textContent;
+  if (fifthsText === null || fifthsText === undefined) return null;
+  const fifths = Number(fifthsText);
+  if (!Number.isFinite(fifths)) return null;
+  const map: Record<number, string> = {
+    '-7': 'Cb major',
+    '-6': 'Gb major',
+    '-5': 'Db major',
+    '-4': 'Ab major',
+    '-3': 'Eb major',
+    '-2': 'Bb major',
+    '-1': 'F major',
+    '0': 'C major',
+    '1': 'G major',
+    '2': 'D major',
+    '3': 'A major',
+    '4': 'E major',
+    '5': 'B major',
+    '6': 'F# major',
+    '7': 'C# major',
+  };
+  return map[fifths] ?? null;
+}
+
+export function parseMusicXmlSummary(
+  musicxml: string,
+  fallbackTempoBpm: number | null = null,
+  fallbackKeySignature: string | null = null,
+): ParsedTranscriptionSummary {
+  const xml = new DOMParser().parseFromString(musicxml, 'application/xml');
+  const parserError = xml.querySelector('parsererror');
+  if (parserError) {
+    throw new Error('Backend returned invalid MusicXML.');
+  }
+
+  const notes: ParsedTranscriptionNote[] = [];
+  const segments: ParsedTranscriptionSegment[] = [];
+  let currentSegment: ParsedTranscriptionSegment | null = null;
+  let currentSeconds = 0;
+
+  for (const measureEl of Array.from(xml.querySelectorAll('part > measure'))) {
+    const measureDivisions = Number(measureEl.querySelector('attributes > divisions')?.textContent ?? `${DIVISIONS_FALLBACK}`);
+    const divisions = Number.isFinite(measureDivisions) && measureDivisions > 0 ? measureDivisions : DIVISIONS_FALLBACK;
+
+    for (const noteEl of Array.from(measureEl.querySelectorAll(':scope > note'))) {
+      const durationDivisions = Number(noteEl.querySelector('duration')?.textContent ?? '0');
+      const durationSeconds = durationDivisions / divisions;
+      const isRest = noteEl.querySelector('rest') !== null;
+      const isChordTone = noteEl.querySelector('chord') !== null;
+      const startSeconds = isChordTone && notes.length > 0 ? notes[notes.length - 1].startSeconds : currentSeconds;
+
+      if (!isRest) {
+        const note = {
+          pitch: pitchNameFromNote(noteEl),
+          startSeconds,
+          durationSeconds,
+        };
+        notes.push(note);
+        if (!currentSegment) {
+          currentSegment = {
+            startSeconds,
+            endSeconds: startSeconds + durationSeconds,
+            noteCount: 1,
+          };
+        } else {
+          currentSegment.endSeconds = Math.max(currentSegment.endSeconds, startSeconds + durationSeconds);
+          currentSegment.noteCount += 1;
+        }
+      } else if (currentSegment) {
+        segments.push(currentSegment);
+        currentSegment = null;
+      }
+
+      if (!isChordTone) {
+        currentSeconds += durationSeconds;
+      }
+    }
+  }
+
+  if (currentSegment) {
+    segments.push(currentSegment);
+  }
+
+  return {
+    notes,
+    segments,
+    tempoBpm: fallbackTempoBpm ?? readTempoBpm(xml),
+    keySignature: fallbackKeySignature ?? readKeySignature(xml),
+  };
+}

--- a/frontend/src/registry.ts
+++ b/frontend/src/registry.ts
@@ -15,6 +15,7 @@ import { partMixerFeature } from './features/part-mixer/index';
 import { pitchOverlayFeature } from './features/pitch-overlay/index';
 import { audioPreflightFeature } from './features/audio-preflight/index';
 import { progressHistoryFeature } from './features/progress-history/index';
+import { transcriptionFeature } from './features/transcription/index';
 
 export type { Feature } from './feature-types';
 
@@ -26,4 +27,5 @@ export const features: Feature[] = [
   pitchOverlayFeature,
   audioPreflightFeature,
   progressHistoryFeature,
+  transcriptionFeature,
 ];


### PR DESCRIPTION
### Motivation
- Provide a first-class frontend workflow to upload audio, invoke the offline transcription pipeline, and obtain MusicXML from the backend for users who want to transcribe recorded audio. 
- Surface quick, actionable feedback (validation, progress, retry) and a minimal parsed view (notes, segments, tempo, key) so users can inspect results before downloading MusicXML.
- Support both synchronous MusicXML responses and async/polled backend responses so the UI works with either immediate or deferred transcription backends.

### Description
- Added a new frontend feature `transcriptionFeature` (`frontend/src/features/transcription/index.ts`) that implements file selection, client-side validation, UI states (busy/error/retry/complete) and MusicXML download linking. 
- Implemented a transcription API helper and MusicXML parser (`frontend/src/features/transcription/transcription-api.ts`) that handles direct MusicXML responses and polling-style async responses, and converts MusicXML into a summary of notes, segmentation boundaries, tempo and key for display.
- Registered the feature and UI slot: updated `frontend/src/registry.ts` and added the transcription panel and styles to `frontend/index.html` so the feature mounts into the main app layout. 
- Added unit and integration tests: `transcription-api.test.ts` for parser logic and `index.test.ts` for the mounted feature flow and validation UI. 
- Closes #282

### Testing
- Ran lint and backend tests with `uv run ruff check backend/ --fix`, `uv run ruff check backend/` and `uv run pytest -v`, which completed successfully (`287 passed, 35 skipped`).
- Ran frontend tests with `npm test` (Vitest) and `tsc --noEmit`, which completed successfully (`40 test files, 221 tests passed`).
- Verified production build with `npm run build` (Vite) completed without fatal errors.
- All automated checks mentioned above passed in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bb2db8713083279a15785fc5670b7c)