### PR TITLE
fix: replace deprecated audioop WAV processing

### DIFF
--- a/backend/tests/test_transcription_api_cli.py
+++ b/backend/tests/test_transcription_api_cli.py
@@ -25,6 +25,7 @@ from backend.transcription_service import (
     _frames_to_note_events,
     _load_wav_mono,
     _midi_to_pitch_name,
+    _pcm_bytes_to_float32,
     transcribe_audio_file,
 )
 
@@ -295,6 +296,26 @@ def test_load_wav_mono_supports_24bit_pcm(tmp_path: Path) -> None:
     samples = _load_wav_mono(audio_path)
 
     assert samples == pytest.approx(np.array([0.0, 0.5, -0.5], dtype=np.float32), abs=1e-6)
+
+
+@pytest.mark.parametrize(
+    ("sample_width", "raw_frames", "expected"),
+    [
+        (1, bytes((0, 128, 255)), np.array([-1.0, 0.0, 127.0 / 128.0], dtype=np.float32)),
+        (2, np.array([-32768, 0, 32767], dtype="<i2").tobytes(), np.array([-1.0, 0.0, 32767.0 / 32768.0], dtype=np.float32)),
+        (3, bytes((0, 0, 128, 0, 0, 0, 255, 255, 127)), np.array([-1.0, 0.0, 8388607.0 / 8388608.0], dtype=np.float32)),
+        (4, np.array([-(1 << 31), 0, (1 << 31) - 1], dtype="<i4").tobytes(), np.array([-1.0, 0.0, ((2**31 - 1) / float(2**31))], dtype=np.float32)),
+    ],
+)
+def test_pcm_bytes_to_float32_supports_all_sample_widths(
+    sample_width: int,
+    raw_frames: bytes,
+    expected: np.ndarray,
+) -> None:
+    samples = _pcm_bytes_to_float32(raw_frames, sample_width=sample_width)
+
+    assert samples.dtype == np.float32
+    assert samples == pytest.approx(expected, abs=1e-6)
 
 
 def test_frames_to_note_events_splits_on_pitch_jumps_and_discards_short_segments() -> None:

--- a/backend/transcription_service.py
+++ b/backend/transcription_service.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 import wave
 
-import audioop
+import librosa
 import numpy as np
 
 from backend.audio.music_analysis import estimate_key, estimate_tempo
@@ -108,25 +108,30 @@ def _load_wav_mono(path: Path) -> np.ndarray:
     if sample_width not in {1, 2, 3, 4}:
         raise TranscriptionError(f"Unsupported WAV sample width: {sample_width * 8} bits")
 
-    if channels > 1:
-        raw_frames = audioop.tomono(raw_frames, sample_width, 0.5, 0.5)
-
-    if sample_rate != SAMPLE_RATE:
-        raw_frames, _ = audioop.ratecv(raw_frames, sample_width, 1, sample_rate, SAMPLE_RATE, None)
-
-    if sample_width == 3:
-        samples = _pcm24le_to_float32(raw_frames)
-    elif sample_width == 1:
-        samples = (np.frombuffer(raw_frames, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
-    elif sample_width == 2:
-        samples = np.frombuffer(raw_frames, dtype="<i2").astype(np.float32) / 32768.0
-    else:
-        samples = np.frombuffer(raw_frames, dtype="<i4").astype(np.float32) / 2147483648.0
-
+    samples = _pcm_bytes_to_float32(raw_frames, sample_width=sample_width)
     if len(samples) == 0:
         raise TranscriptionError("Audio file is empty")
 
+    if channels > 1:
+        usable = len(samples) - (len(samples) % channels)
+        samples = samples[:usable].reshape(-1, channels).mean(axis=1)
+
+    if sample_rate != SAMPLE_RATE:
+        samples = librosa.resample(samples, orig_sr=sample_rate, target_sr=SAMPLE_RATE)
+
     return np.clip(samples.astype(np.float32, copy=False), -1.0, 1.0)
+
+
+def _pcm_bytes_to_float32(raw_frames: bytes, *, sample_width: int) -> np.ndarray:
+    if sample_width == 3:
+        return _pcm24le_to_float32(raw_frames)
+    if sample_width == 1:
+        return (np.frombuffer(raw_frames, dtype=np.uint8).astype(np.float32) - 128.0) / 128.0
+    if sample_width == 2:
+        return np.frombuffer(raw_frames, dtype="<i2").astype(np.float32) / 32768.0
+    if sample_width == 4:
+        return np.frombuffer(raw_frames, dtype="<i4").astype(np.float32) / 2147483648.0
+    raise TranscriptionError(f"Unsupported WAV sample width: {sample_width * 8} bits")
 
 
 def _pcm24le_to_float32(raw_frames: bytes) -> np.ndarray:


### PR DESCRIPTION
### Motivation
- Remove the use of the deprecated `audioop` module and replace WAV preprocessing with a clearer, numpy-first pipeline that is easier to test and maintain.
- Ensure all WAV sample widths (8/16/24/32-bit) are decoded consistently and that stereo files are downmixed and resampled reliably for the pitch pipeline.

### Description
- Replace `audioop` usage in `backend/transcription_service.py` with a new `_pcm_bytes_to_float32()` helper that converts 8/16/24/32-bit PCM bytes into normalized `float32` samples. 
- Downmix multi-channel audio by reshaping and taking a NumPy channel mean and resample to `SAMPLE_RATE` using `librosa.resample` instead of `audioop.ratecv`.
- Add unit-test coverage in `backend/tests/test_transcription_api_cli.py` to validate PCM decoding for 1-, 2-, 3-, and 4-byte sample widths and import the new helper in the test module. 
- Remove the `audioop` import and update the WAV-loading logic to use the shared PCM helper; the change targets robust decoding and removes the deprecated dependency (Closes #286). 

### Testing
- Ran linter fixes with `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which succeeded. 
- Ran focused tests with `uv run pytest backend/tests/test_transcription_api_cli.py -v` and then the full suite with `uv run pytest -v`, and all automated tests passed (full suite: tests passed and hardware tests were auto-skipped in CI where applicable).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf177c65a0832784fa15b0841d0004)