### PR TITLE
refactor: validate session save requests

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -5,7 +5,6 @@ Day 6: Playback state machine + real WebSocket pitch stream.
 
 import asyncio
 from pathlib import Path
-from typing import Any
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, HTTPException
 from fastapi.middleware.cors import CORSMiddleware
@@ -16,6 +15,7 @@ from .score.parser import parse_musicxml
 from .score.upload import persist_upload_to_temp
 from .audio.capture import list_input_devices, default_input_device_id
 from .audio.pipeline import PlaybackPipeline, _CLIENT_QUEUE_MAXSIZE
+from .models.session import SessionSaveRequest
 from .session.store import list_sessions, read_session, save_session
 from .transcription_service import TranscriptionError, transcribe_audio_file
 
@@ -248,31 +248,10 @@ async def pitch_stream(websocket: WebSocket) -> None:
 
 
 @app.post("/session/save")
-async def session_save(payload: dict[str, Any]) -> JSONResponse:
-    frames = payload.get("frames")
-    if not isinstance(frames, list):
-        raise HTTPException(status_code=400, detail="frames must be a list")
-
-    normalized_payload = {
-        "title": str(payload.get("title") or "Untitled"),
-        "part": str(payload.get("part") or "Unknown"),
-        "created_at": str(payload.get("created_at") or ""),
-        "frames": [
-            {
-                "t": float(frame.get("t", 0.0)),
-                "beat": float(frame.get("beat", 0.0)),
-                "midi": None if frame.get("midi") is None else float(frame.get("midi")),
-                "conf": float(frame.get("conf", 0.0)),
-                "expected_midi": None if frame.get("expected_midi") is None else float(frame.get("expected_midi")),
-                "measure": None if frame.get("measure") is None else int(frame.get("measure")),
-            }
-            for frame in frames
-            if isinstance(frame, dict)
-        ],
-    }
-
-    session_id, _ = save_session(normalized_payload)
-    return JSONResponse({"id": session_id, "frame_count": len(normalized_payload["frames"])})
+async def session_save(request: SessionSaveRequest) -> JSONResponse:
+    payload = request.model_dump(mode="json")
+    session_id, _ = save_session(payload)
+    return JSONResponse({"id": session_id, "frame_count": len(payload["frames"])})
 
 
 @app.get("/session/list")

--- a/backend/models/__init__.py
+++ b/backend/models/__init__.py
@@ -1,5 +1,6 @@
 """Shared backend models."""
 
+from .session import SessionFrameIn, SessionSaveRequest
 from .transcription import (
     NoteEvent,
     PitchFrame,
@@ -9,6 +10,8 @@ from .transcription import (
 )
 
 __all__ = [
+    "SessionFrameIn",
+    "SessionSaveRequest",
     "PitchFrame",
     "NoteEvent",
     "RestEvent",

--- a/backend/models/session.py
+++ b/backend/models/session.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class SessionFrameIn(BaseModel):
+    """Validated session frame payload used by session-save requests."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    t: float = Field(ge=0)
+    beat: float = Field(ge=0)
+    midi: float | None = Field(default=None, ge=0, le=127)
+    conf: float = Field(ge=0.0, le=1.0)
+    expected_midi: float | None = Field(default=None, ge=0, le=127)
+    measure: int | None = Field(default=None, ge=0)
+
+
+class SessionSaveRequest(BaseModel):
+    """Validated request body for POST /session/save."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    title: str = Field(min_length=1, max_length=200)
+    part: str = Field(min_length=1)
+    created_at: datetime | None = None
+    frames: list[SessionFrameIn] = Field(min_length=1, max_length=50000)

--- a/backend/tests/test_session_api.py
+++ b/backend/tests/test_session_api.py
@@ -47,6 +47,15 @@ def test_session_save_list_get(monkeypatch) -> None:
         assert len(detail.json()["frames"]) == 1
 
 
+def test_session_save_openapi_schema_uses_typed_request_model() -> None:
+    """OpenAPI must expose SessionSaveRequest as the /session/save request body schema."""
+    from backend.main import app
+
+    schema = app.openapi()
+    request_body = schema["paths"]["/session/save"]["post"]["requestBody"]["content"]["application/json"]["schema"]
+    assert request_body == {"$ref": "#/components/schemas/SessionSaveRequest"}
+
+
 def test_session_get_missing_returns_404() -> None:
     from backend.main import app
     client = TestClient(app)
@@ -54,13 +63,14 @@ def test_session_get_missing_returns_404() -> None:
     assert response.status_code == 404
 
 
-def test_session_save_non_list_frames_returns_400(monkeypatch) -> None:
-    """POST /session/save with frames that is not a list must return 400."""
+def test_session_save_missing_frames_returns_422(monkeypatch) -> None:
+    """POST /session/save must reject payloads missing the required frames list."""
     with tempfile.TemporaryDirectory() as tmp:
         client = _client_with_tmp(monkeypatch, tmp)
-        response = client.post("/session/save", json={"frames": "not-a-list"})
-        assert response.status_code == 400
-        assert "frames must be a list" in response.json()["detail"]
+        response = client.post("/session/save", json={"title": "Song", "part": "Tenor"})
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any(error["loc"] == ["body", "frames"] for error in detail)
 
 
 def test_session_save_null_optional_frame_fields(monkeypatch) -> None:
@@ -87,22 +97,22 @@ def test_session_save_null_optional_frame_fields(monkeypatch) -> None:
         assert frame["measure"] is None
 
 
-def test_session_save_non_dict_frame_items_filtered(monkeypatch) -> None:
-    """Non-dict items in the frames list must be silently dropped."""
+def test_session_save_conf_out_of_range_returns_422(monkeypatch) -> None:
+    """Frame confidence outside 0.0-1.0 must be rejected by request validation."""
     with tempfile.TemporaryDirectory() as tmp:
         client = _client_with_tmp(monkeypatch, tmp)
         payload = {
             "title": "Song",
             "part": "Alto",
             "frames": [
-                "bad-item",
-                {"t": 1.0, "beat": 0.5, "midi": 62.0, "conf": 0.8,
+                {"t": 1.0, "beat": 0.5, "midi": 62.0, "conf": 1.5,
                  "expected_midi": 62, "measure": 2},
             ],
         }
-        save = client.post("/session/save", json=payload)
-        assert save.status_code == 200
-        assert save.json()["frame_count"] == 1
+        response = client.post("/session/save", json=payload)
+        assert response.status_code == 422
+        detail = response.json()["detail"]
+        assert any(error["loc"] == ["body", "frames", 0, "conf"] for error in detail)
 
 
 # ── store.py unit tests ────────────────────────────────────────────────────────


### PR DESCRIPTION
### Motivation
- Improve validation and OpenAPI schema for the `POST /session/save` endpoint by replacing a raw `dict[str, Any]` body and manual normalization with typed request models.
- Prevent malformed or out-of-range frame values from silently being accepted and make validation errors descriptive and machine-readable.

### Description
- Add `SessionFrameIn` and `SessionSaveRequest` Pydantic models in `backend/models/session.py` with range/length constraints and `extra="forbid"` to reject unknown fields.
- Update `backend/main.py` so `POST /session/save` accepts `SessionSaveRequest` and persists `request.model_dump(mode="json")` instead of manual normalization.
- Export the new models via `backend/models/__init__.py` so they appear in the shared models package and OpenAPI components.
- Extend `backend/tests/test_session_api.py` to assert the OpenAPI request schema references `SessionSaveRequest` and to cover validation rejections (missing `frames` and out-of-range `conf`).
- Closes #290

### Testing
- Ran linter: `uv run ruff check backend/ --fix` and `uv run ruff check backend/` which completed successfully.
- Ran full test suite: `uv run pytest -v` resulting in all tests passing (`288 passed, 35 skipped`).
- Confirmed the modified session API tests pass and the OpenAPI schema exposes the typed request model.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf17c0da708327b0a2f0f2acd07474)