### PR TITLE
fix: propagate capture timestamps through pitch queue

### DIFF
--- a/backend/audio/capture.py
+++ b/backend/audio/capture.py
@@ -8,6 +8,7 @@ Fills a ring buffer with overlapping 2048-sample windows at 22050 Hz.
 from __future__ import annotations
 
 import threading
+import time
 from dataclasses import dataclass
 from typing import Callable
 
@@ -109,7 +110,7 @@ class RingBuffer:
         self,
         window_size: int = WINDOW_SIZE,
         hop_size: int = HOP_SIZE,
-        on_window: Callable[[np.ndarray], None] | None = None,
+        on_window: Callable[[np.ndarray, float], None] | None = None,
     ) -> None:
         self._window_size = window_size
         self._hop_size = hop_size
@@ -129,7 +130,7 @@ class RingBuffer:
 
             if self._fill == self._window_size:
                 if self._on_window:
-                    self._on_window(self._buf.copy())
+                    self._on_window(self._buf.copy(), time.monotonic() * 1000.0)
                 # Slide by hop_size (50% overlap)
                 self._buf[: self._window_size - self._hop_size] = self._buf[
                     self._hop_size :
@@ -155,7 +156,7 @@ class MicCapture:
         self,
         device_id: int | None = None,
         sample_rate: int = SAMPLE_RATE,
-        on_window: Callable[[np.ndarray], None] | None = None,
+        on_window: Callable[[np.ndarray, float], None] | None = None,
     ) -> None:
         self._device_id = device_id  # None → sounddevice default
         self._sample_rate = sample_rate

--- a/backend/audio/pitch.py
+++ b/backend/audio/pitch.py
@@ -63,6 +63,12 @@ class EngineRuntimeInfo:
     mode: str
 
 
+@dataclass(frozen=True)
+class QueuedWindow:
+    window: np.ndarray
+    capture_time_ms: float
+
+
 def resolve_engine_runtime(force_cpu: bool = False) -> EngineRuntimeInfo:
     """Resolve active engine from env + runtime override + CUDA availability."""
     env_engine = os.getenv("PITCH_ENGINE", "").strip().lower()
@@ -250,7 +256,7 @@ class PitchPipeline:
             self._engine = Engine.PYIN
         self._on_frame = on_frame
         self._device = "cuda" if self._engine == Engine.TORCHCREPE else "cpu"
-        self._queue: queue.Queue[np.ndarray | None] = queue.Queue(
+        self._queue: queue.Queue[QueuedWindow | None] = queue.Queue(
             maxsize=self._QUEUE_MAXSIZE
         )
         self._thread: threading.Thread | None = None
@@ -274,10 +280,16 @@ class PitchPipeline:
             self._thread.join(timeout=2.0)
         log.info("PitchPipeline stopped (dropped frames: %d)", self._dropped_frames)
 
-    def push(self, window: np.ndarray) -> None:
+    def push(self, window: np.ndarray, capture_time_ms: float | None = None) -> None:
         """Non-blocking: drops window if worker is falling behind."""
+        queued_window = QueuedWindow(
+            window=window,
+            capture_time_ms=(
+                time.monotonic() * 1000.0 if capture_time_ms is None else capture_time_ms
+            ),
+        )
         try:
-            self._queue.put_nowait(window)
+            self._queue.put_nowait(queued_window)
         except queue.Full:
             self._dropped_frames += 1
 
@@ -296,13 +308,15 @@ class PitchPipeline:
     def _worker(self) -> None:
         self._warmup()
         while True:
-            window = self._queue.get()
-            if window is None:
+            queued_window = self._queue.get()
+            if queued_window is None:
                 break
-            capture_time_ms = time.monotonic() * 1000.0
             try:
                 t0 = time.monotonic()
-                frame = self._infer(window, capture_time_ms)
+                frame = self._infer(
+                    queued_window.window,
+                    queued_window.capture_time_ms,
+                )
                 elapsed_ms = (time.monotonic() - t0) * 1000.0
                 if elapsed_ms > 80.0:
                     log.warning("Inference took %.1f ms (target <80ms)", elapsed_ms)

--- a/backend/tests/test_capture.py
+++ b/backend/tests/test_capture.py
@@ -36,14 +36,14 @@ class TestRingBuffer:
     def test_no_window_before_full(self):
         """Callback must not fire until a full window is accumulated."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
         buf.push(np.zeros(WINDOW_SIZE - 1, dtype=np.float32))
         assert len(fired) == 0
 
     def test_window_fires_on_completion(self):
         """Exactly one window fires when we push the final sample."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
         buf.push(np.zeros(WINDOW_SIZE, dtype=np.float32))
         assert len(fired) == 1
         assert fired[0].shape == (WINDOW_SIZE,)
@@ -51,7 +51,7 @@ class TestRingBuffer:
     def test_window_content_is_correct(self):
         """The window should contain the samples we pushed."""
         received = []
-        buf = RingBuffer(on_window=lambda w: received.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: received.append(w.copy()))
         samples = np.arange(WINDOW_SIZE, dtype=np.float32)
         buf.push(samples)
         assert np.allclose(received[0], samples)
@@ -59,7 +59,7 @@ class TestRingBuffer:
     def test_overlap_second_window(self):
         """After the first window, pushing HOP_SIZE more samples triggers a second window."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
         buf.push(np.ones(WINDOW_SIZE, dtype=np.float32))
         buf.push(np.full(HOP_SIZE, 2.0, dtype=np.float32))
         assert len(fired) == 2
@@ -67,7 +67,7 @@ class TestRingBuffer:
     def test_overlap_content(self):
         """Second window should contain the last HOP_SIZE samples of the first block."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
 
         first = np.ones(WINDOW_SIZE, dtype=np.float32)
         second_hop = np.full(HOP_SIZE, 9.0, dtype=np.float32)
@@ -81,7 +81,7 @@ class TestRingBuffer:
     def test_small_chunks(self):
         """Pushing in small chunks should accumulate correctly."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
         chunk = np.ones(64, dtype=np.float32)
         for _ in range(WINDOW_SIZE // 64):
             buf.push(chunk)
@@ -90,7 +90,7 @@ class TestRingBuffer:
     def test_large_push_multiple_windows(self):
         """A push larger than WINDOW_SIZE should produce multiple windows."""
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(w.copy()))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(w.copy()))
         buf.push(np.zeros(WINDOW_SIZE + HOP_SIZE * 2, dtype=np.float32))
         assert len(fired) >= 2
 
@@ -115,7 +115,7 @@ class TestRingBuffer:
         expected_windows = max(0, (total_samples - WINDOW_SIZE) // HOP_SIZE + 1)
 
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(1))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(1))
 
         # Push in HOP_SIZE blocks — exactly how sounddevice delivers frames
         samples_pushed = 0
@@ -138,7 +138,7 @@ class TestRingBuffer:
         expected_windows = max(0, (total_samples - WINDOW_SIZE) // HOP_SIZE + 1)
 
         fired = []
-        buf = RingBuffer(on_window=lambda w: fired.append(1))
+        buf = RingBuffer(on_window=lambda w, _: fired.append(1))
 
         # Push all at once — worst case for any naive implementation
         buf.push(np.zeros(total_samples, dtype=np.float32))

--- a/backend/tests/test_pitch.py
+++ b/backend/tests/test_pitch.py
@@ -297,6 +297,29 @@ class TestPitchPipeline:
         pipeline.stop()
         assert not errors
 
+    def test_frame_time_ms_uses_push_timestamp_not_worker_completion_time(self):
+        received = []
+        pipeline = PitchPipeline(engine=Engine.PYIN, on_frame=received.append)
+        release_worker = threading.Event()
+        push_time_ms = 12_345.0
+
+        pipeline._warmup = lambda: None  # type: ignore[method-assign]
+
+        def fake_infer(_window, capture_time_ms):
+            release_worker.wait(timeout=1.0)
+            return PitchFrame(time_ms=capture_time_ms, midi=69.0, confidence=0.95)
+
+        pipeline._infer = fake_infer  # type: ignore[method-assign]
+        pipeline.start()
+        pipeline.push(np.zeros(2048, dtype=np.float32), capture_time_ms=push_time_ms)
+        time.sleep(0.05)
+        release_worker.set()
+        time.sleep(0.05)
+        pipeline.stop()
+
+        assert len(received) == 1
+        assert received[0].time_ms == push_time_ms
+
 
 class TestThinBuildFallback:
     def test_resolve_engine_without_torch_uses_pyin(self, monkeypatch):


### PR DESCRIPTION
### Motivation

- Ensure emitted `PitchFrame.time_ms` reflects the actual audio capture time rather than the worker completion time when the inference worker is delayed. 
- Prevent timestamp shifts caused by reading `time.monotonic()` at dequeue time which broke alignment under backpressure or slow inference.

### Description

- Capture a timestamp on the audio thread inside `RingBuffer` and change the `on_window` callback signature to `on_window(window, capture_time_ms)` so windows carry their capture time immediately.  
- Add `QueuedWindow` dataclass and change `PitchPipeline.push()` to accept an optional `capture_time_ms`, enqueue a `QueuedWindow`, and have the worker use the queued timestamp when calling `_infer`.  
- Update `MicCapture` to pass the ring-buffer timestamp and adjust the queue type and worker loop to propagate timestamps instead of re-reading `time.monotonic()` at dequeue.  
- Update tests: adapt `backend/tests/test_capture.py` callbacks to the new signature and add a regression test in `backend/tests/test_pitch.py` that delays the worker to verify `PitchFrame.time_ms` equals the push timestamp.  
- Closes #285

### Testing

- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/` with no lint failures.  
- Ran the full test suite with `uv run pytest -v`, which completed successfully (`288 passed, 35 skipped`).  
- All changed unit tests and the new regression test passed locally.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf176a691883278815b67162f2396e)