### PR TITLE
test: tighten quantizer migration coverage on top of refactor: remove quantized spans shim

### DIFF
--- a/backend/tests/test_transcription_api_cli.py
+++ b/backend/tests/test_transcription_api_cli.py
@@ -316,24 +316,30 @@ def test_frames_to_note_events_splits_on_pitch_jumps_and_discards_short_segments
     assert events[1].end_time > events[1].start_time
 
 
-def test_quantize_note_events_directly_covers_rest_alignment_and_pitch_validation() -> None:
-    """Validate canonical quantizer behavior for rests, ties, confidence, and pitch validation."""
+A4_HZ = 440.0
+B4_HZ = 493.88
+C5_HZ = 523.25
+D5_HZ = 587.33
+
+
+def test_quantize_note_events_covers_canonical_rest_and_tie_behavior() -> None:
+    """Validate canonical quantizer behavior for rests, ties, gaps, and dropped tiny events."""
 
     assert quantize_note_events([], tempo_bpm=120.0, time_signature="4/4") == []
 
     quantized_events = quantize_note_events(
         [
-            NoteEvent(start_time=1.0, end_time=1.75, pitch=440.0, confidence=0.75),
-            NoteEvent(start_time=2.0, end_time=2.5, pitch=493.88, confidence=0.6),
-            NoteEvent(start_time=2.75, end_time=3.375, pitch=523.25, confidence=0.9),
-            NoteEvent(start_time=4.0, end_time=4.0001, pitch=587.33, confidence=0.2),
+            NoteEvent(start_time=1.0, end_time=1.75, pitch=A4_HZ, confidence=0.75),
+            NoteEvent(start_time=2.0, end_time=2.5, pitch=B4_HZ, confidence=0.6),
+            NoteEvent(start_time=2.75, end_time=3.375, pitch=C5_HZ, confidence=0.9),
+            NoteEvent(start_time=4.0, end_time=4.0001, pitch=D5_HZ, confidence=0.2),
         ],
         tempo_bpm=120.0,
         time_signature="4/4",
     )
 
-    # The quantizer fills any beat gap before the next note with explicit rest events,
-    # so a note starting at 1.0s at 120 BPM is preceded by a two-beat rest.
+    # The quantizer emits explicit rests for every beat gap between quantized note spans,
+    # so a note that lands on beat 2 is preceded by a two-beat rest from the measure start.
     assert [event.event_type for event in quantized_events] == [
         "rest",
         "note",
@@ -353,7 +359,28 @@ def test_quantize_note_events_directly_covers_rest_alignment_and_pitch_validatio
     assert [event.tie_start for event in quantized_events] == [False, False, False, False, False, True, False]
     assert [event.tie_stop for event in quantized_events] == [False, False, False, False, False, False, True]
 
-    assert _midi_to_pitch_name(440.0) == "A4"
+
+def test_quantize_note_events_handles_off_grid_alignment_and_sequential_notes() -> None:
+    quantized_events = quantize_note_events(
+        [
+            NoteEvent(start_time=0.12, end_time=0.66, pitch=A4_HZ, confidence=0.8),
+            NoteEvent(start_time=0.88, end_time=1.42, pitch=B4_HZ, confidence=0.65),
+            NoteEvent(start_time=1.42, end_time=1.89, pitch=C5_HZ, confidence=0.55),
+        ],
+        tempo_bpm=120.0,
+        time_signature="4/4",
+    )
+
+    assert [event.event_type for event in quantized_events] == ["rest", "note", "rest", "note", "note"]
+    assert [event.duration_beats for event in quantized_events] == pytest.approx([0.25, 1.0, 0.5, 1.0, 1.0])
+    assert [event.pitch for event in quantized_events] == [None, "A4", None, "B4", "C5"]
+    assert [event.confidence for event in quantized_events] == pytest.approx([1.0, 0.8, 1.0, 0.65, 0.55])
+    assert all(not event.tie_start for event in quantized_events)
+    assert all(not event.tie_stop for event in quantized_events)
+
+
+def test_midi_to_pitch_name_validates_frequency_inputs() -> None:
+    assert _midi_to_pitch_name(A4_HZ) == "A4"
 
     with pytest.raises(TranscriptionError, match="pitch must be positive"):
         _midi_to_pitch_name(-1.0)


### PR DESCRIPTION
### Motivation
- The compatibility shim `_build_quantized_spans` was removed in the refactor and tests must exercise the canonical `quantize_note_events` behavior instead.  
- The migrated tests previously mixed pitch-name validation with quantization expectations and used magic numeric literals, which risked format mismatches and unclear intent.  
- Review requested explicit verification that no references to `_build_quantized_spans` remain and that all tests that relied on the shim were migrated.  
- Additional edge cases (off-grid starts, sequential notes, tiny/zero-duration drops, confidence propagation, rest insertion, and pitch validation) needed explicit coverage to match the original shim behavior.

### Description
- Reworked `backend/tests/test_transcription_api_cli.py` to replace the single migrated test with clearer, focused tests and named pitch constants (`A4_HZ`, `B4_HZ`, `C5_HZ`, `D5_HZ`).  
- Added `test_quantize_note_events_covers_canonical_rest_and_tie_behavior` to assert canonical rest insertion, tie splitting, duration decomposition, and confidence propagation.  
- Added `test_quantize_note_events_handles_off_grid_alignment_and_sequential_notes` to exercise off-grid alignment, multiple sequential notes, and tied vs non-tied behavior.  
- Split pitch-name validation into `test_midi_to_pitch_name_validates_frequency_inputs` to isolate input validation (negative, zero, non-finite) from quantization logic, and added inline maintainer comments explaining rest-insertion expectations.  
- Performed a full-repo search for `_build_quantized_spans` and `QuantizedEvent`-style shim imports and confirmed no remaining transcription-service shim references exist; updated test assertions to match the canonical quantizer output format (pitch name strings where appropriate).

### Testing
- Verified no remaining shim references with `rg -n "_build_quantized_spans|from .* import .*QuantizedEvent|import QuantizedEvent" backend .github README.md` which confirmed only production/test model references remain and no transcription shim imports were left.  
- Ran linter autofix and checks with `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, both succeeded.  
- Ran the updated test file with `uv run pytest backend/tests/test_transcription_api_cli.py -v` and observed the file-level tests pass.  
- Ran the full test suite with `uv run pytest -v` and observed all tests passing (`289 passed, 35 skipped`).  

Closes #287

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1dfd28c883279b951b202f70e20b)