### PR TITLE
fix: make backend CORS origins configurable

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Comma-separated frontend origins allowed to call the FastAPI backend.
+# Defaults to the Vite dev server origins used during local development.
+CORS_ORIGINS=http://localhost:5173,http://127.0.0.1:5173
+
+# Set to 1 when the backend is launched by the packaged Electron app.
+# Electron mode relaxes CORS for app:// and file:// renderers by using
+# allow_origins=["*"] with allow_credentials disabled.
+ELECTRON_MODE=0

--- a/README.md
+++ b/README.md
@@ -168,6 +168,18 @@ Open http://localhost:5173
 
 API docs: http://localhost:8000/docs
 
+### Backend environment variables
+
+- `CORS_ORIGINS` — comma-separated list of allowed browser origins for the FastAPI backend. Defaults to `http://localhost:5173,http://127.0.0.1:5173`. Override this when running Vite on a different port or when you need multiple frontend origins during development.
+- `ELECTRON_MODE` — set to `1` when the backend is launched by the packaged Electron app. In this mode the backend uses wildcard CORS with credentials disabled so `app://` and `file://` renderers can reach the API without rebuilding the backend.
+
+Example:
+
+```powershell
+$env:CORS_ORIGINS="http://localhost:5174,http://127.0.0.1:4173"
+just dev-backend
+```
+
 ---
 
 ## Tech stack

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,6 +4,7 @@ Day 6: Playback state machine + real WebSocket pitch stream.
 """
 
 import asyncio
+import os
 from pathlib import Path
 
 from fastapi import FastAPI, WebSocket, WebSocketDisconnect, UploadFile, File, HTTPException
@@ -19,19 +20,45 @@ from .models.session import SessionSaveRequest
 from .session.store import list_sessions, read_session, save_session
 from .transcription_service import TranscriptionError, transcribe_audio_file
 
+DEFAULT_CORS_ORIGINS = (
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+)
+
+
+def _parse_cors_origins(raw_value: str | None) -> list[str]:
+    if raw_value is None:
+        return list(DEFAULT_CORS_ORIGINS)
+
+    origins = [origin.strip() for origin in raw_value.split(",") if origin.strip()]
+    return origins or list(DEFAULT_CORS_ORIGINS)
+
+
+def _cors_settings_from_env() -> dict[str, bool | list[str]]:
+    if os.getenv("ELECTRON_MODE", "").strip() == "1":
+        return {
+            "allow_origins": ["*"],
+            "allow_credentials": False,
+        }
+
+    return {
+        "allow_origins": _parse_cors_origins(os.getenv("CORS_ORIGINS")),
+        "allow_credentials": True,
+    }
+
+
 app = FastAPI(
     title="sing-attune",
     description="MusicXML pitch tracking backend",
     version="0.2.0",
 )
 
+_cors_settings = _cors_settings_from_env()
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:5173",
-        "http://127.0.0.1:5173",
-    ],
-    allow_credentials=True,
+    allow_origins=_cors_settings["allow_origins"],
+    allow_credentials=_cors_settings["allow_credentials"],
     allow_methods=["*"],
     allow_headers=["*"],
 )

--- a/backend/tests/test_cors_config.py
+++ b/backend/tests/test_cors_config.py
@@ -1,0 +1,70 @@
+import importlib
+
+
+def _load_main_module(monkeypatch, **env):
+    for key in ("CORS_ORIGINS", "ELECTRON_MODE"):
+        monkeypatch.delenv(key, raising=False)
+
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+    import backend.main as backend_main
+
+    return importlib.reload(backend_main)
+
+
+def test_default_cors_origins_preserve_existing_behavior(monkeypatch):
+    backend_main = _load_main_module(monkeypatch)
+
+    assert backend_main._parse_cors_origins(None) == [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+    assert backend_main._cors_settings_from_env() == {
+        "allow_origins": [
+            "http://localhost:5173",
+            "http://127.0.0.1:5173",
+        ],
+        "allow_credentials": True,
+    }
+
+
+
+def test_cors_origins_env_var_overrides_defaults(monkeypatch):
+    backend_main = _load_main_module(
+        monkeypatch,
+        CORS_ORIGINS="http://localhost:4173, https://example.com , ,http://127.0.0.1:3000",
+    )
+
+    assert backend_main._cors_settings_from_env() == {
+        "allow_origins": [
+            "http://localhost:4173",
+            "https://example.com",
+            "http://127.0.0.1:3000",
+        ],
+        "allow_credentials": True,
+    }
+
+
+
+def test_empty_cors_origins_env_var_falls_back_to_defaults(monkeypatch):
+    backend_main = _load_main_module(monkeypatch, CORS_ORIGINS=" , ")
+
+    assert backend_main._cors_settings_from_env()["allow_origins"] == [
+        "http://localhost:5173",
+        "http://127.0.0.1:5173",
+    ]
+
+
+
+def test_electron_mode_uses_wildcard_without_credentials(monkeypatch):
+    backend_main = _load_main_module(
+        monkeypatch,
+        ELECTRON_MODE="1",
+        CORS_ORIGINS="https://should-not-be-used.example",
+    )
+
+    assert backend_main._cors_settings_from_env() == {
+        "allow_origins": ["*"],
+        "allow_credentials": False,
+    }


### PR DESCRIPTION
### Motivation
- The backend previously had CORS allowed origins hardcoded to Vite dev defaults which breaks when the frontend runs on non-default ports, multiple instances, or in packaged Electron renderers.
- Electron-packaged renderers use `app://` or file URLs that cannot match the existing localhost-only origins, so Electron launches need a different CORS policy.

### Description
- Read allowed origins from a new `CORS_ORIGINS` environment variable (comma-separated) with the existing `http://localhost:5173,http://127.0.0.1:5173` defaults preserved via `DEFAULT_CORS_ORIGINS` and `_parse_cors_origins` in `backend/main.py`.
- Add `_cors_settings_from_env()` which switches to wildcard origins and disables credentials when `ELECTRON_MODE=1`, and wire the result into `app.add_middleware(CORSMiddleware, ...)` in `backend/main.py`.
- Add `.env.example` and update `README.md` to document `CORS_ORIGINS` and `ELECTRON_MODE` usage and example overrides.
- Add unit tests `backend/tests/test_cors_config.py` covering the default behaviour, custom comma-separated origin parsing, empty-value fallback, and Electron wildcard behaviour.
- Closes #288

### Testing
- Ran `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, which completed with no lint failures.
- Ran `uv run pytest -v`, all backend tests passed: `297 passed, 35 skipped`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bfb6527b2c8327b1c83c6c86ec86a3)