### PR TITLE
fix(onboarding): keep the score panel usable on first run

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -675,6 +675,17 @@
       padding: 8px 20px 12px;
       font-size: 0.78rem;
     }
+    #progress-history-panel.is-empty {
+      max-height: 108px;
+      padding-bottom: 8px;
+    }
+    #progress-history-panel.is-empty #progress-range-chart,
+    #progress-history-panel.is-empty #progress-history-list {
+      display: none;
+    }
+    #progress-history-panel.is-empty .progress-actions {
+      opacity: 0.6;
+    }
     #progress-history-header {
       display: flex;
       align-items: center;

--- a/frontend/src/features/progress-history/index.ts
+++ b/frontend/src/features/progress-history/index.ts
@@ -63,10 +63,16 @@ function mount(slot: HTMLElement): void {
 
   const render = (sessions: PracticeSessionSummary[]): void => {
     latestSessions = sessions;
-    if (sessions.length === 0) {
-      summaryEl.textContent = 'No saved sessions yet. Start singing to build your history.';
+    const panelEl = document.getElementById('progress-history-panel') as HTMLElement | null;
+    const isEmpty = sessions.length === 0;
+    panelEl?.classList.toggle('is-empty', isEmpty);
+    exportJsonBtn.disabled = isEmpty;
+    exportCsvBtn.disabled = isEmpty;
+
+    if (isEmpty) {
+      summaryEl.textContent = 'No saved sessions yet. Your score stays front and center until you finish a rehearsal.';
       rangeChartEl.innerHTML = '';
-      listEl.innerHTML = '<div class="progress-empty">No sessions saved.</div>';
+      listEl.innerHTML = '<div class="progress-empty">Finish one take to unlock practice history and exports.</div>';
       return;
     }
 


### PR DESCRIPTION
### Motivation

- E2E tests showed the score area collapsing on first-run layouts because the empty practice-history panel consumed too much vertical space, so the UI needs to keep the score panel readable for new users. 
- History exports should be disabled until a rehearsal exists and the empty-state copy should clearly surface that the score remains the primary focus. 

### Description

- Add compact empty-state styling for the practice-history panel (`#progress-history-panel.is-empty`) in `frontend/index.html` so the empty history occupies less vertical space. 
- Update `frontend/src/features/progress-history/index.ts` to detect empty history, toggle the `is-empty` class, disable the export buttons when no sessions exist, and replace the empty-state copy with guidance that keeps the score front-and-center. 
- This is a targeted follow-up to the onboarding changes to prevent the first-run layout regression while preserving the full history view once sessions exist. 

### Testing

- Ran lint autofix and lint checks with `uv run ruff check backend/ --fix` and `uv run ruff check backend/`, and they passed. 
- Ran backend tests with `uv run pytest -v` and they passed (`306 passed, 35 skipped`). 
- Ran frontend unit tests with `cd frontend && npm test` and the test run completed successfully. 
- Built the frontend with `cd frontend && npm run build` and the production build completed successfully. 
- Attempted `cd frontend && npx playwright test e2e/app.spec.ts --project=chromium` but the Playwright browser install failed (`npx playwright install chromium` returned `403 Domain forbidden`), so the local E2E run was blocked; the change is intended to address the previously-observed E2E score-panel regression. 

Closes #304

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bffc4e315c8327a71d904e6fd56b76)